### PR TITLE
Refactor: Isolate "extract metadata" process from "generate_rdf_file" in submission parsing 

### DIFF
--- a/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb
@@ -22,13 +22,11 @@ module LinkedData
 
           begin
             # Set default metadata
-            set_default_metadata(logger)
+            set_default_metadata
             logger.info('Default metadata set.')
           rescue StandardError => e
             logger.error("Error while setting default metadata: #{e}")
           end
-
-
 
         end
 

--- a/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/submission_metadata_extractor.rb
@@ -202,40 +202,40 @@ module LinkedData
         # Return a hash with the best literal value for an URI
         # it selects the literal according to their language: no language > english > french > other languages
         def select_metadata_literal(metadata_uri, metadata_literal, hash)
-          if metadata_literal.is_a?(RDF::Literal)
-            if hash.has_key?(metadata_uri)
-              if metadata_literal.has_language?
-                if !hash[metadata_uri].has_language?
+          return unless metadata_literal.is_a?(RDF::Literal)
+
+          if hash.key?(metadata_uri)
+            if metadata_literal.has_language?
+              if !hash[metadata_uri].has_language?
+                return hash
+              else
+                case metadata_literal.language
+                when :en, :eng
+                  # Take the value with english language over other languages
+                  hash[metadata_uri] = metadata_literal
                   return hash
-                else
-                  if metadata_literal.language == :en || metadata_literal.language == :eng
-                    # Take the value with english language over other languages
+                when :fr, :fre
+                  # If no english, take french
+                  if hash[metadata_uri].language == :en || hash[metadata_uri].language == :eng
+                    return hash
+                  else
                     hash[metadata_uri] = metadata_literal
                     return hash
-                  elsif metadata_literal.language == :fr || metadata_literal.language == :fre
-                    # If no english, take french
-                    if hash[metadata_uri].language == :en || hash[metadata_uri].language == :eng
-                      return hash
-                    else
-                      hash[metadata_uri] = metadata_literal
-                      return hash
-                    end
-                  else
-                    return hash
                   end
+                else
+                  return hash
                 end
-              else
-                # Take the value with no language in priority (considered as a default)
-                hash[metadata_uri] = metadata_literal
-                return hash
               end
             else
+              # Take the value with no language in priority (considered as a default)
               hash[metadata_uri] = metadata_literal
               return hash
             end
+          else
+            hash[metadata_uri] = metadata_literal
+            hash
           end
         end
-
 
         # A function to extract additional metadata
         # Take the literal data if the property is pointing to a literal

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -1311,6 +1311,7 @@ eos
         # Wrap the whole process so we can email results
         begin
           process_rdf = false
+          extract_metadata = false
           index_search = false
           index_properties = false
           index_commit = false
@@ -1321,6 +1322,7 @@ eos
 
           if options.empty?
             process_rdf = true
+            extract_metadata = true
             index_search = true
             index_properties = true
             index_commit = true
@@ -1330,6 +1332,7 @@ eos
             archive = false
           else
             process_rdf = options[:process_rdf] == true ? true : false
+            extract_metadata = options[:extract_metadata] == true ? true : false
             index_search = options[:index_search] == true ? true : false
             index_properties = options[:index_properties] == true ? true : false
             index_commit = options[:index_commit] == true ? true : false
@@ -1397,7 +1400,7 @@ eos
                 remove_submission_status(status) #remove RDF status before starting
 
                 generate_rdf(logger, reasoning: reasoning)
-                extract_metadata(logger, options[:params])
+
                 add_submission_status(status)
                 self.save
               rescue Exception => e
@@ -1409,7 +1412,11 @@ eos
                 # If RDF generation fails, no point of continuing
                 raise e
               end
+            end
 
+            extract_metadata(logger, options[:params]) if extract_metadata || process_rdf
+
+            if process_rdf
               file_path = self.uploadFilePath
               callbacks = {
                 missing_labels: {

--- a/test/data/ontology_files/agrooeMappings-05-05-2016.owl
+++ b/test/data/ontology_files/agrooeMappings-05-05-2016.owl
@@ -255,7 +255,7 @@
 	<prov:wasGeneratedBy rdf:resource="http://lirmm.fr/2015/wasGeneratedBy.owl"/>
 	<prov:wasInvalidatedBy rdf:resource="http://lirmm.fr/2015/wasInvalidatedBy.owl"/>
 
-	
+    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
 </rdf:Description>
 
 <!-- DESCRIPTION OF RESOURCES INVOLVED IN METADATA DESCRIPTION -->

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1035,6 +1035,7 @@ eos
     sub = LinkedData::Models::Ontology.find("AGROOE").first.latest_submission()
     sub.bring_remaining
     assert_equal false, sub.deprecated
+    assert_equal  " AGROOE is an ontology used to test the metadata extraction,  AGROOE is an ontology to illustrate how to describe their ontologies", sub.description
     assert_equal " LIRMM (default name) ", sub.publisher
     assert_equal " URI DC terms identifiers ", sub.identifier
     assert_equal ["http://lexvo.org/id/iso639-3/fra", "http://lexvo.org/id/iso639-3/eng"].sort, sub.naturalLanguage.sort

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -1041,7 +1041,7 @@ eos
     assert_equal "Vincent Emonet, Anne Toulet, Benjamine Dessay, Léontine Dessaiterm, Augustine Doap", sub.hasContributor
     assert_equal [RDF::URI.new("http://lirmm.fr/2015/ontology/door-relation.owl"), RDF::URI.new("http://lirmm.fr/2015/ontology/dc-relation.owl"),
                   RDF::URI.new("http://lirmm.fr/2015/ontology/dcterms-relation.owl"), RDF::URI.new("http://lirmm.fr/2015/ontology/voaf-relation.owl")].sort, sub.ontologyRelatedTo.sort
-    assert_equal 13, sub.numberOfClasses
+    assert_equal 18, sub.numberOfClasses
   end
 
   def test_submission_delete_remove_files


### PR DESCRIPTION
### Changes

- Refactor `OntologySubmission::MetadataExtractor` module
- Extract `extract_metadata` action from `process_rdf`
- Update extract metadata test to cover owl:imports bugs 