### PR TITLE
Feature: Add github_id and ordcid_id to user model

### DIFF
--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -18,6 +18,9 @@ module LinkedData
       attribute :role, enforce: [:role, :list], :default => lambda {|x| [LinkedData::Models::Users::Role.default]}
       attribute :firstName
       attribute :lastName
+      attribute :github_id, enforce: [:unique]
+      attribute :orcid_id, enforce: [:unique]
+      attribute :is_subscribe, enforce: [:existence], :default => lambda {|x| false}
       attribute :created, enforce: [:date_time], :default => lambda { |record| DateTime.now }
       attribute :passwordHash, enforce: [:existence]
       attribute :apikey, enforce: [:unique], :default => lambda {|x| SecureRandom.uuid}

--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -18,9 +18,8 @@ module LinkedData
       attribute :role, enforce: [:role, :list], :default => lambda {|x| [LinkedData::Models::Users::Role.default]}
       attribute :firstName
       attribute :lastName
-      attribute :github_id, enforce: [:unique]
-      attribute :orcid_id, enforce: [:unique]
-      attribute :is_subscribe, enforce: [:existence], :default => lambda {|x| false}
+      attribute :githubId, enforce: [:unique]
+      attribute :orcidId, enforce: [:unique]
       attribute :created, enforce: [:date_time], :default => lambda { |record| DateTime.now }
       attribute :passwordHash, enforce: [:existence]
       attribute :apikey, enforce: [:unique], :default => lambda {|x| SecureRandom.uuid}


### PR DESCRIPTION
As a result of this issue [Update Login & Register views design #130](https://github.com/ontoportal-lirmm/bioportal_web_ui/issues/130) , it was concluded that new fields ( `github_id`, `ordcid_id`, ) need to be added to the user model.

## Changes made

Add the fields `github_id` and `ordcid_id` to the `user model`.