### PR TITLE
Add request language to @context

### DIFF
--- a/lib/ontologies_linked_data/serializer.rb
+++ b/lib/ontologies_linked_data/serializer.rb
@@ -84,10 +84,13 @@ module LinkedData
     end
 
     def self.serialize(type, obj, params, request)
-      only = params["display"] || []
-      only = only.split(",") unless only.kind_of?(Array)
-      only, all = [], true if only[0].eql?("all")
-      options = {:only => only, :all => all, :params => params, :request => request}
+      language = params['language'] || Goo.main_languages.first
+      only = params['display'] || []
+      only = only.split(',') unless only.is_a?(Array)
+      all = only[0] == 'all'
+      only = all ? [] : only
+
+      options = { only: only, language: language, all: all, params: params, request: request } 
       LinkedData::Serializers.serialize(obj, type, options)
     end
 

--- a/lib/ontologies_linked_data/serializer.rb
+++ b/lib/ontologies_linked_data/serializer.rb
@@ -84,13 +84,13 @@ module LinkedData
     end
 
     def self.serialize(type, obj, params, request)
-      language = params['language'] || Goo.main_languages.first
+      lang = params['lang'] || Goo.main_languages.first
       only = params['display'] || []
       only = only.split(',') unless only.is_a?(Array)
       all = only[0] == 'all'
       only = all ? [] : only
 
-      options = { only: only, language: language, all: all, params: params, request: request } 
+      options = { only: only, lang: lang, all: all, params: params, request: request } 
       LinkedData::Serializers.serialize(obj, type, options)
     end
 

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -41,7 +41,7 @@ module LinkedData
             hash.merge!(context)
           end
         end
-
+        hash.map { |h| h['@context']['@language'] = options[:language] }
         MultiJson.dump(hash)
       end
 

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -27,7 +27,7 @@ module LinkedData
               hash["links"].merge!(generate_links_context(hashed_obj)) if generate_context?(options)
             end
           end
-
+          
           # Generate context
           if current_cls.ancestors.include?(Goo::Base::Resource) && !current_cls.embedded?
             if generate_context?(options)
@@ -40,8 +40,8 @@ module LinkedData
             context = {"@context" => context_hash}
             hash.merge!(context)
           end
+          hash['@context']['@language'] = options[:lang]
         end
-        hash.map { |h| h['@context']['@language'] = options[:lang] }
         MultiJson.dump(hash)
       end
 

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -41,7 +41,7 @@ module LinkedData
             hash.merge!(context)
           end
         end
-        hash.map { |h| h['@context']['@language'] = options[:language] }
+        hash.map { |h| h['@context']['@language'] = options[:lang] }
         MultiJson.dump(hash)
       end
 


### PR DESCRIPTION
## Description

When we call this endpoint : 

https://data.stageportal.lirmm.fr/ontologies/INRAETHES/classes/http%3A%2F%2Fopendata.inrae.fr%2FthesaurusINRAE%2Fc_2ecd2d30 

we will see in the `@context` the `@language` of the request, like in the following : 

```json
"@context": {
  "@language": "en"
  "@vocab": "http://data.bioontology.org/metadata/",
},
```
Issue: https://github.com/ontoportal-lirmm/ontologies_linked_data/issues/65

## Changes made

- [x] Get `language` from the `request query-params` , if it's  not exist set it to the default `Goo lang`
- [x] Add `@language` to the response object in the `serialize` function

