### PR TITLE
Add subscribed attribute to the user model

### DIFF
--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -18,6 +18,7 @@ module LinkedData
       attribute :role, enforce: [:role, :list], :default => lambda {|x| [LinkedData::Models::Users::Role.default]}
       attribute :firstName
       attribute :lastName
+      attribute :subscribed, default: false
       attribute :created, enforce: [:date_time], :default => lambda { |record| DateTime.now }
       attribute :passwordHash, enforce: [:existence]
       attribute :apikey, enforce: [:unique], :default => lambda {|x| SecureRandom.uuid}


### PR DESCRIPTION
## Description

When we call `users endpoint ` we will see `subscribed ` attribute.


Issue: https://github.com/ontoportal-lirmm/ontologies_linked_data/issues/64

## Changes made

- [x] Add `subscribed ` to user model

