### PR TITLE
Feature: Support multilingual - Add read one language from request parameter tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'rest-client'
 gem 'rsolr', '~> 1.0'
 gem 'rubyzip', '~> 1.0'
 gem 'thin'
+gem 'request_store'
 
 # Testing
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -35,5 +35,5 @@ group :development do
 end
 
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ontoportal-lirmm/goo', branch: 'development'
+gem 'goo', github: 'ontoportal-lirmm/goo', branch: 'feature/support-multilingual-read-one-language-from-request-parameter'
 gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -36,5 +36,5 @@ group :development do
 end
 
 # NCBO gems (can be from a local dev path or from rubygems/git)
-gem 'goo', github: 'ontoportal-lirmm/goo', branch: 'feature/support-multilingual-read-one-language-from-request-parameter'
+gem 'goo', github: 'ontoportal-lirmm/goo', branch: 'development'
 gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: 92bed925de041eb5a40adbe8788a74c6c7cb1020
-  branch: feature/support-multilingual-read-one-language-from-request-parameter
+  revision: b769c165906163e30a026dba511ae1069c4eed3d
+  branch: development
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -156,7 +156,7 @@ GEM
     rexml (3.2.5)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rubocop (1.47.0)
+    rubocop (1.48.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: 3d5bbe1db4a6aca2ff621ccfcdb85a32dbe9704e
-  branch: development
+  revision: d30c5748f27c05d88d5db423f7c4b2355412483b
+  branch: feature/support-multilingual-read-one-language-from-request-parameter
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -39,11 +39,11 @@ GEM
     bcrypt (3.1.18)
     builder (3.2.4)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
     cube-ruby (0.0.3)
     daemons (1.4.1)
-    date (3.3.2)
+    date (3.3.3)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -52,7 +52,7 @@ GEM
       launchy (~> 2.1)
       mail (~> 2.7)
     eventmachine (1.2.7)
-    faraday (1.10.2)
+    faraday (1.10.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -85,13 +85,13 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     json_pure (2.6.3)
-    launchy (2.5.0)
-      addressable (~> 2.7)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     libxml-ruby (2.9.0)
     logger (1.5.3)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
-    mail (2.8.0)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
@@ -99,7 +99,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     minitest (4.7.5)
     minitest-reporters (0.14.24)
@@ -108,9 +108,9 @@ GEM
       minitest (>= 2.12, < 5.0)
       powerbar
     multi_json (1.15.0)
-    multipart-post (2.2.3)
+    multipart-post (2.3.0)
     net-http-persistent (2.9.4)
-    net-imap (0.3.2)
+    net-imap (0.3.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -124,13 +124,13 @@ GEM
     omni_logger (0.1.4)
       logger
     parallel (1.22.1)
-    parser (3.1.3.0)
+    parser (3.2.1.0)
       ast (~> 2.4.1)
     pony (1.13.1)
       mail (>= 2.0)
     powerbar (2.0.1)
       hashie (>= 1.1.0)
-    pry (0.14.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.1)
@@ -141,11 +141,11 @@ GEM
     rake (10.5.0)
     rdf (1.0.8)
       addressable (>= 2.2)
-    redis (5.0.5)
+    redis (5.0.6)
       redis-client (>= 0.9.0)
-    redis-client (0.11.2)
+    redis-client (0.13.0)
       connection_pool
-    regexp_parser (2.6.1)
+    regexp_parser (2.7.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -154,22 +154,22 @@ GEM
     rexml (3.2.5)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rubocop (1.40.0)
+    rubocop (1.47.0)
       json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.2.1)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.23.0, < 2.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.24.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.27.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (1.3.0)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -186,17 +186,18 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thread_safe (0.3.6)
-    timeout (0.3.1)
+    timeout (0.3.2)
     tzinfo (0.3.61)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (2.3.0)
+    unicode-display_width (2.4.2)
     uuid (2.3.9)
       macaddr (~> 1.0)
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   activesupport (~> 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: d30c5748f27c05d88d5db423f7c4b2355412483b
+  revision: 92bed925de041eb5a40adbe8788a74c6c7cb1020
   branch: feature/support-multilingual-read-one-language-from-request-parameter
   specs:
     goo (0.0.2)
@@ -146,6 +146,8 @@ GEM
     redis-client (0.13.0)
       connection_pool
     regexp_parser (2.7.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -219,6 +221,7 @@ DEPENDENCIES
   rack (~> 1.0)
   rack-test (~> 0.6)
   rake (~> 10.0)
+  request_store
   rest-client
   rsolr (~> 1.0)
   rubocop

--- a/lib/ontologies_linked_data/concerns/mappings/mapping_creator.rb
+++ b/lib/ontologies_linked_data/concerns/mappings/mapping_creator.rb
@@ -81,8 +81,8 @@ module LinkedData
           process.relation = relations_array
           process.creator = user
 
-          process.subject_source_id = RDF::URI.new(source_uri || mapping_process_hash[:subject_source_id])
-          process.object_source_id = RDF::URI.new(object_uri || mapping_process_hash[:object_source_id])
+          process.subject_source_id = create_uri(source_uri || mapping_process_hash[:subject_source_id])
+          process.object_source_id = create_uri(object_uri || mapping_process_hash[:object_source_id])
           process.date = mapping_process_hash[:date] ? DateTime.parse(mapping_process_hash[:date]) : DateTime.now
           process_fields = %i[source source_name comment name source_contact_info]
           process_fields.each do |att|
@@ -92,6 +92,9 @@ module LinkedData
         end
 
         private
+        def create_uri(value)
+          RDF::URI.new(value) unless value.nil?
+        end
 
         def save_rest_mapping(classes, process)
           LinkedData::Mappings.create_rest_mapping(classes, process)

--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -90,7 +90,11 @@ module LinkedData
       end
 
       def to_s
-        self.username.to_s
+        if bring?(:username)
+          self.id.to_s
+        else
+          self.username.to_s
+        end
       end
 
       private

--- a/test/models/notes/test_note.rb
+++ b/test/models/notes/test_note.rb
@@ -67,11 +67,11 @@ class TestNote < LinkedData::TestCase
         relatedOntology: [@@ontology],
       })
 
-      assert_equal false, n.exist?(reload=true)
+      assert_equal false, n.exist?
       n.save
-      assert_equal true, n.exist?(reload=true)
+      assert_equal true, n.exist?
       n.delete
-      assert_equal false, n.exist?(reload=true)
+      assert_equal false, n.exist?
     ensure
       n.delete if !n.nil? && n.persistent?
     end

--- a/test/models/skos/test_collections.rb
+++ b/test/models/skos/test_collections.rb
@@ -10,7 +10,7 @@ class TestCollections < LinkedData::TestOntologyCommon
 
   def test_collections_all
     submission_parse('INRAETHES', 'Testing skos',
-                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.rdf',
+                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
                      1,
                      process_rdf: true, index_search: false,
                      run_metrics: false, reasoning: false)
@@ -31,7 +31,7 @@ class TestCollections < LinkedData::TestOntologyCommon
 
   def test_collection_members
     submission_parse('INRAETHES', 'Testing skos',
-                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.rdf',
+                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
                      1,
                      process_rdf: true, index_search: false,
                      run_metrics: false, reasoning: false)

--- a/test/models/skos/test_schemes.rb
+++ b/test/models/skos/test_schemes.rb
@@ -10,7 +10,7 @@ class TestSchemes < LinkedData::TestOntologyCommon
 
   def test_schemes_all
     submission_parse('INRAETHES', 'Testing skos',
-                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.rdf',
+                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
                      1,
                      process_rdf: true, index_search: false,
                      run_metrics: false, reasoning: false)

--- a/test/models/skos/test_skos_xl.rb
+++ b/test/models/skos/test_skos_xl.rb
@@ -9,7 +9,7 @@ class TestSkosXlLabel < LinkedData::TestOntologyCommon
 
   def test_skos_xl_label_all
     submission_parse('INRAETHES', 'Testing skos',
-                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.rdf',
+                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
                      1,
                      process_rdf: true, index_search: false,
                      run_metrics: false, reasoning: false)
@@ -27,17 +27,13 @@ class TestSkosXlLabel < LinkedData::TestOntologyCommon
 
   def test_class_skos_xl_label
     submission_parse('INRAETHES', 'Testing skos',
-                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.rdf',
+                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
                      1,
                      process_rdf: true, index_search: false,
                      run_metrics: false, reasoning: false)
     ont = 'INRAETHES'
     ont = LinkedData::Models::Ontology.find(ont).first
     sub = ont.latest_submission
-
-    sub.bring_remaining
-    sub.hasOntologyLanguage = LinkedData::Models::OntologyFormat.find('SKOS').first
-    sub.save
 
     class_test = LinkedData::Models::Class.find('http://opendata.inrae.fr/thesaurusINRAE/c_16193')
                                           .in(sub).include(:prefLabel,

--- a/test/models/test_class_main_lang.rb
+++ b/test/models/test_class_main_lang.rb
@@ -10,25 +10,25 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
   end
 
   def test_map_attribute_found
-    cls = parse_and_get_class lang: ['fr']
+    cls = parse_and_get_class lang: [:FR]
     cls.bring :unmapped
     LinkedData::Models::Class.map_attributes(cls)
-    assert_equal 'entité matérielle detaillée', cls.label.first
-    assert_equal 'skos prefLabel fr', cls.prefLabel
+    assert_equal ['entité matérielle detaillée'], cls.label
+    assert_includes ['skos prefLabel fr', 'skos prefLabel rien'], cls.prefLabel
     assert_equal ['entité fra', 'entite rien'], cls.synonym
   end
 
   def test_map_attribute_not_found
-    cls = parse_and_get_class lang: ['es']
+    cls = parse_and_get_class lang: [:ES]
     cls.bring :unmapped
     LinkedData::Models::Class.map_attributes(cls)
     assert_equal ['material detailed entity', 'entité matérielle detaillée'], cls.label
     assert_equal 'skos prefLabel rien', cls.prefLabel
-    assert_equal ['entita esp' , 'entite rien' ], cls.synonym
+    assert_equal ['entita esp', 'entite rien'], cls.synonym
   end
 
   def test_map_attribute_secondary_lang
-    cls = parse_and_get_class lang: %w[es fr]
+    cls = parse_and_get_class lang: %i[ES FR]
     cls.bring :unmapped
     LinkedData::Models::Class.map_attributes(cls)
     assert_equal ['entité matérielle detaillée'], cls.label
@@ -38,14 +38,14 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
 
 
   def test_label_main_lang_fr_found
-    cls = parse_and_get_class lang: ['fr']
-    assert_equal 'entité matérielle detaillée', cls.label.first
+    cls = parse_and_get_class lang: [:FR]
+    assert_equal ['entité matérielle detaillée'], cls.label
     assert_equal 'skos prefLabel fr', cls.prefLabel
     assert_equal ['entité fra', 'entite rien'], cls.synonym
   end
 
   def test_label_main_lang_not_found
-    cls = parse_and_get_class lang: ['es']
+    cls = parse_and_get_class lang: [:ES]
 
     assert_equal ['material detailed entity', 'entité matérielle detaillée'], cls.label
     assert_equal 'skos prefLabel rien', cls.prefLabel
@@ -54,7 +54,7 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
 
   def test_label_secondary_lang
     # 'es' will not be found so will take 'fr' if fond or anything else
-    cls = parse_and_get_class lang: %w[es fr]
+    cls = parse_and_get_class lang: %i[ES FR]
 
     assert_equal ['entité matérielle detaillée'], cls.label
     assert_equal 'skos prefLabel rien', cls.prefLabel
@@ -62,7 +62,7 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
   end
 
   def test_label_main_lang_en_found
-    cls = parse_and_get_class lang: ['en']
+    cls = parse_and_get_class lang: [:EN]
     assert_equal 'material detailed entity', cls.label.first
     assert_equal 'skos prefLabel en', cls.prefLabel
     assert_equal ['entity eng', 'entite rien'], cls.synonym
@@ -72,7 +72,7 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
   private
 
   def parse_and_get_class(lang:, klass: 'http://lirmm.fr/2015/resource/AGROOE_c_03')
-    lang_set lang
+    lang_set portal_languages: lang
     submission_parse('AGROOE', 'AGROOE Test extract metadata ontology',
                      './test/data/ontology_files/agrooeMappings-05-05-2016.owl', 1,
                      process_rdf: true, index_search: false,
@@ -85,9 +85,7 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
     cls
   end
 
-  def lang_set(lang)
-    Goo.main_languages = lang
-  end
+
 
   def get_ontology_last_submission(ont)
     LinkedData::Models::Ontology.find(ont).first.latest_submission()

--- a/test/models/test_class_main_lang.rb
+++ b/test/models/test_class_main_lang.rb
@@ -3,10 +3,12 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
 
   def self.before_suite
     @@old_main_languages = Goo.main_languages
+    RequestStore.store[:requested_lang] = nil
   end
 
   def self.after_suite
     Goo.main_languages = @@old_main_languages
+    RequestStore.store[:requested_lang] = nil
   end
 
   def test_map_attribute_found
@@ -72,7 +74,7 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
   private
 
   def parse_and_get_class(lang:, klass: 'http://lirmm.fr/2015/resource/AGROOE_c_03')
-    lang_set portal_languages: lang
+    portal_lang_set portal_languages: lang
     submission_parse('AGROOE', 'AGROOE Test extract metadata ontology',
                      './test/data/ontology_files/agrooeMappings-05-05-2016.owl', 1,
                      process_rdf: true, index_search: false,
@@ -86,6 +88,10 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
   end
 
 
+  def portal_lang_set(portal_languages: nil)
+    Goo.main_languages = portal_languages if portal_languages
+    RequestStore.store[:requested_lang] = nil
+  end
 
   def get_ontology_last_submission(ont)
     LinkedData::Models::Ontology.find(ont).first.latest_submission()

--- a/test/models/test_class_request_lang.rb
+++ b/test/models/test_class_request_lang.rb
@@ -1,0 +1,75 @@
+require_relative './test_ontology_common'
+
+class TestClassMainLang < LinkedData::TestOntologyCommon
+
+  def self.after_suite
+    Goo.requested_language = nil
+  end
+
+  def test_requested_language_found
+
+    parse
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
+                            requested_lang: :FR, portal_languages: %i[EN FR ES])
+    assert_equal 'industrialisation', cls.prefLabel
+    assert_equal ['développement industriel'], cls.synonym
+
+    properties = cls.properties
+    assert_equal ['développement industriel'], properties.select { |x| x.to_s['altLabel'] }.values.first.map(&:to_s)
+    assert_equal ['industrialisation'], properties.select { |x| x.to_s['prefLabel'] }.values.first.map(&:to_s)
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
+                            requested_lang: :EN, portal_languages: %i[FR EN ES])
+    assert_equal 'industrialization', cls.prefLabel
+    assert_equal ['industrial development'], cls.synonym
+
+    properties = cls.properties
+    assert_equal ['industrial development'], properties.select { |x| x.to_s['altLabel'] }.values.first.map(&:to_s)
+    assert_equal ['industrialization'], properties.select { |x| x.to_s['prefLabel'] }.values.first.map(&:to_s)
+
+  end
+
+  def test_requested_language_not_found
+    parse
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
+                            requested_lang: :ES, portal_languages: %i[EN FR ES])
+    assert_nil cls.prefLabel
+    assert_empty cls.synonym
+
+    properties = cls.properties
+    assert_empty properties.select { |x| x.to_s['altLabel'] }.values
+    assert_empty properties.select { |x| x.to_s['prefLabel'] }.values
+
+  end
+
+  private
+
+  def parse
+    submission_parse('INRAETHES', 'Testing skos',
+                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
+                     1,
+                     process_rdf: true, index_search: false,
+                     run_metrics: false, reasoning: false)
+  end
+
+  def lang_set(requested_lang: nil, portal_languages: nil)
+    Goo.main_languages = portal_languages if portal_languages
+    Goo.requested_language = requested_lang
+  end
+
+  def get_class(cls, ont)
+    sub = LinkedData::Models::Ontology.find(ont).first.latest_submission
+    LinkedData::Models::Class.find(cls).in(sub).first
+  end
+
+  def get_class_by_lang(cls, requested_lang:, portal_languages: [])
+    lang_set requested_lang: requested_lang, portal_languages: portal_languages
+    cls = get_class(cls, 'INRAETHES')
+    refute_nil cls
+    cls.bring_remaining
+    cls.bring :unmapped
+    cls
+  end
+end

--- a/test/models/test_ontology.rb
+++ b/test/models/test_ontology.rb
@@ -308,11 +308,11 @@ class TestOntology < LinkedData::TestOntologyCommon
                                      })
     assert pc.valid?
     pc.save
-    assert_equal true, pc.exist?(reload=true)
+    assert_equal true, pc.exist?
 
     assert n.valid?
     n.save()
-    assert_equal true, n.exist?(reload=true)
+    assert_equal true, n.exist?
 
     review_params = {
         :creator => u,
@@ -329,12 +329,12 @@ class TestOntology < LinkedData::TestOntologyCommon
 
     r = LinkedData::Models::Review.new(review_params)
     r.save()
-    assert_equal true, r.exist?(reload=true)
+    assert_equal true, r.exist?
 
     o1.delete()
-    assert_equal false, n.exist?(reload=true)
-    assert_equal false, r.exist?(reload=true)
-    assert_equal false, o1.exist?(reload=true)
+    assert_equal false, n.exist?
+    assert_equal false, r.exist?
+    assert_equal false, o1.exist?
     o2.delete()
   end
 

--- a/test/models/test_provisional_class.rb
+++ b/test/models/test_provisional_class.rb
@@ -37,19 +37,19 @@ class TestProvisionalClass < LinkedData::TestOntologyCommon
 
     # Before save
     assert_equal LinkedData::Models::ProvisionalClass.where(label: label).all.count, 0
-    assert_equal false, pc.exist?(reload=true)
+    assert_equal false, pc.exist?
 
     pc.save
 
     # After save
     assert_equal LinkedData::Models::ProvisionalClass.where(label: label).all.count, 1
-    assert_equal true, pc.exist?(reload=true)
+    assert_equal true, pc.exist?
 
     pc.delete
 
     # After delete
     assert_equal LinkedData::Models::ProvisionalClass.where(label: label).all.count, 0
-    assert_equal false, pc.exist?(reload=true)
+    assert_equal false, pc.exist?
   end
 
   def test_provisional_class_valid

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -218,11 +218,11 @@ module LinkedData
     def model_lifecycle_test(m)
       assert_equal(true, m.is_a?(LinkedData::Models::Base), 'Expected is_a?(LinkedData::Models::Base).')
       assert_equal(true, m.valid?, "Expected valid model: #{m.errors}")
-      assert_equal(false, m.exist?(reload=true), 'Given model is already saved, expected one that is not.')
+      assert_equal(false, m.exist?, 'Given model is already saved, expected one that is not.')
       m.save
-      assert_equal(true, m.exist?(reload=true), 'Failed to save model.')
+      assert_equal(true, m.exist?, 'Failed to save model.')
       m.delete
-      assert_equal(false, m.exist?(reload=true), 'Failed to delete model.')
+      assert_equal(false, m.exist?, 'Failed to delete model.')
     end
 
     def self.count_pattern(pattern)


### PR DESCRIPTION
### Context
https://github.com/ontoportal-lirmm/ontologies_linked_data/issues/63
### Changes

- Add tests for the requested language using INRAETHES as the use case 
- Add request_store gem, used to save the requested language as a global variable for the current request.
- Some code refactoring in the old tests (e.g exist?)