### PR TITLE
Feature: return requested languages in @language - part 2 - multiple langugaes

### DIFF
--- a/lib/ontologies_linked_data/serializer.rb
+++ b/lib/ontologies_linked_data/serializer.rb
@@ -84,7 +84,7 @@ module LinkedData
     end
 
     def self.serialize(type, obj, params, request)
-      lang = params['lang'] || params['language']|| Goo.main_languages.first
+      lang = params['lang'] || params['language'] # || Goo.main_languages.first
       only = params['display'] || []
       only = only.split(',') unless only.is_a?(Array)
       all = only[0] == 'all'

--- a/lib/ontologies_linked_data/serializer.rb
+++ b/lib/ontologies_linked_data/serializer.rb
@@ -84,7 +84,9 @@ module LinkedData
     end
 
     def self.serialize(type, obj, params, request)
-      lang = (params['lang'] || params['language'] || 'all').upcase # || Goo.main_languages.first
+      
+      lang = self.get_language(params)
+
       only = params['display'] || []
       only = only.split(',') unless only.is_a?(Array)
       all = only[0] == 'all'
@@ -104,6 +106,12 @@ module LinkedData
       else
         false
       end
+    end
+
+    def self.get_language(params)
+      lang = params['lang'] || params['language'] || 'all'
+      lang = lang.split(',').map {|l| l.downcase.to_sym}
+      return lang.length == 1 ? lang.first : lang
     end
 
   end

--- a/lib/ontologies_linked_data/serializer.rb
+++ b/lib/ontologies_linked_data/serializer.rb
@@ -84,7 +84,7 @@ module LinkedData
     end
 
     def self.serialize(type, obj, params, request)
-      lang = params['lang'] || params['language'] # || Goo.main_languages.first
+      lang = params['lang'] || params['language'] || 'ALL' # || Goo.main_languages.first
       only = params['display'] || []
       only = only.split(',') unless only.is_a?(Array)
       all = only[0] == 'all'

--- a/lib/ontologies_linked_data/serializer.rb
+++ b/lib/ontologies_linked_data/serializer.rb
@@ -84,7 +84,7 @@ module LinkedData
     end
 
     def self.serialize(type, obj, params, request)
-      lang = params['lang'] || params['language'] || 'ALL' # || Goo.main_languages.first
+      lang = (params['lang'] || params['language'] || 'all').upcase # || Goo.main_languages.first
       only = params['display'] || []
       only = only.split(',') unless only.is_a?(Array)
       all = only[0] == 'all'

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -7,20 +7,8 @@ module LinkedData
 
       def self.serialize(obj, options = {})
         
-        result_lang = ''
+        result_lang = self.get_languages(obj.submission, options[:lang])
 
-        if obj.submission
-          
-          obj.submission.bring :naturalLanguage
-          langauges = get_submission_languages(obj.submission.naturalLanguage)
-                  
-          # intersection of the two arrays , if the requested language is not :all
-          result_lang = options[:lang] == :all ? langauges : options[:lang] & langauges
-          result_lang = result_lang.first if result_lang.length == 1
-
-        end
-        
-       
         hash = obj.to_flex_hash(options) do |hash, hashed_obj|
           current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class
 
@@ -61,6 +49,22 @@ module LinkedData
       end
 
       private
+
+      def self.get_languages(submission, user_languages)
+        
+        if submission
+          
+          submission.bring :naturalLanguage
+          langauges = get_submission_languages(submission.naturalLanguage)
+                  
+          # intersection of the two arrays , if the requested language is not :all
+          result_lang = user_languages == :all ? langauges : user_languages & langauges
+          result_lang = result_lang.first if result_lang.length == 1
+
+        end
+
+        return result_lang
+      end
 
       def self.get_submission_languages(submission_natural_language = [])
         submission_natural_language.map { |natural_language| natural_language["iso639"] && natural_language.split('/').last[0..1].to_sym }.compact

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -7,7 +7,8 @@ module LinkedData
 
       def self.serialize(obj, options = {})
         
-        result_lang = self.get_languages(obj&.submission, options[:lang])
+        submission = obj.respond_to?(:submission) ? obj.submission : nil
+        result_lang = self.get_languages(submission, options[:lang])
 
         hash = obj.to_flex_hash(options) do |hash, hashed_obj|
           current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -7,7 +7,7 @@ module LinkedData
 
       def self.serialize(obj, options = {})
         
-        result_lang = self.get_languages(obj.submission, options[:lang])
+        result_lang = self.get_languages(obj&.submission, options[:lang])
 
         hash = obj.to_flex_hash(options) do |hash, hashed_obj|
           current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -43,7 +43,7 @@ module LinkedData
             context = {"@context" => context_hash}
             hash.merge!(context)
           end
-          hash['@context']['@language'] = result_lang
+          hash['@context']['@language'] = result_lang if hash['@context']
         end
         MultiJson.dump(hash)
       end


### PR DESCRIPTION
## Description 

This pull request aims to remove the assignment of platform languages to the requested language and return the requested language in @language. This will allow us to filter search results based solely on the requested language.

Related to: https://github.com/ontoportal-lirmm/goo/pull/32

And follow up of https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/73
## Screenshots

1. 
![image](https://user-images.githubusercontent.com/35062242/234597942-a11b7534-de9e-42a0-acde-9d5df4e65434.png)

2.
![image](https://user-images.githubusercontent.com/35062242/234598072-64510566-e858-4d8d-a549-d066afa73597.png)
 
### Resources
https://data.testportal.lirmm.fr/ontologies/INRAETHES/latest_submission?display=naturalLanguage

## Reviewers
@syphax-bouazzouni 