### PR TITLE
Feature: embed metrics for submission model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: b769c165906163e30a026dba511ae1069c4eed3d
+  revision: c3456c45c12ed92d4a3ae43cac7c1d4cdbf290b6
   branch: development
   specs:
     goo (0.0.2)
@@ -32,7 +32,7 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ansi (1.5.0)
     ast (2.4.2)
@@ -40,7 +40,7 @@ GEM
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
-    connection_pool (2.3.0)
+    connection_pool (2.4.0)
     cube-ruby (0.0.3)
     daemons (1.4.1)
     date (3.3.3)
@@ -123,8 +123,8 @@ GEM
     oj (2.18.5)
     omni_logger (0.1.4)
       logger
-    parallel (1.22.1)
-    parser (3.2.1.0)
+    parallel (1.23.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
     pony (1.13.1)
       mail (>= 2.0)
@@ -143,9 +143,9 @@ GEM
       addressable (>= 2.2)
     redis (5.0.6)
       redis-client (>= 0.9.0)
-    redis-client (0.13.0)
+    redis-client (0.14.1)
       connection_pool
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.0)
     request_store (1.5.1)
       rack (>= 1.4)
     rest-client (2.1.0)
@@ -156,17 +156,17 @@ GEM
     rexml (3.2.5)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rubocop (1.48.0)
+    rubocop (1.50.2)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.26.0, < 2.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.27.0)
+    rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
@@ -183,13 +183,13 @@ GEM
     systemu (2.6.5)
     test-unit-minitest (0.9.1)
       minitest (~> 4.7)
-    thin (1.8.1)
+    thin (1.8.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thread_safe (0.3.6)
     timeout (0.3.2)
-    tzinfo (0.3.61)
+    tzinfo (0.3.62)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -199,7 +199,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
-  x86_64-linux
 
 DEPENDENCIES
   activesupport (~> 4)
@@ -233,4 +232,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   2.3.15
+   2.3.23

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -469,7 +469,7 @@ module LinkedData
 
       # Hypermedia settings
       embed :contact, :ontology
-      embed_values :submissionStatus => [:code], :hasOntologyLanguage => [:acronym]
+      embed_values :submissionStatus => [:code], :hasOntologyLanguage => [:acronym], :metrics => [:classes, :individuals, :properties]
       serialize_default :contact, :ontology, :hasOntologyLanguage, :released, :creationDate, :homepage,
                         :publication, :documentation, :version, :description, :status, :submissionId
 

--- a/lib/ontologies_linked_data/monkeypatches/object.rb
+++ b/lib/ontologies_linked_data/monkeypatches/object.rb
@@ -337,6 +337,8 @@ class Object
   end
 
   def add_goo_values(goo_object, embedded_values, attributes_to_embed, options, &block)
+    return if goo_object.nil?
+
     if attributes_to_embed.length > 1
       embedded_values_hash = {}
       attributes_to_embed.each do |a|


### PR DESCRIPTION
### Requirement 

For the submission metrics attribute instead of showing the `id', fetch  the metrics object attributes (classes, individuals, and properties)

#### for `/submissions` endpoint
![image](https://user-images.githubusercontent.com/29259906/235500535-38358a8a-6b39-4aef-af57-e2b43b46db48.png)

#### for `ontologies/{acronym}/submissions` endpoint
![image](https://user-images.githubusercontent.com/29259906/235500762-3fea2119-319f-4990-97a7-09c98019e6ac.png)


### Changes

-  add some metrics attributes as embed values for Submissions (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/8e6d9d007a6e620e446b083a8911a291b331817d)