### PR TITLE
Fix: call to read_restricted?  only if instance_to_base_on not nil

### DIFF
--- a/lib/ontologies_linked_data/security/access_control.rb
+++ b/lib/ontologies_linked_data/security/access_control.rb
@@ -57,12 +57,12 @@ module LinkedData::Security
     def read_restricted_based_on?(based_on)
       if based_on.is_a?(Proc)
         instance_to_base_on = based_on.call(self)
-        restricted = instance_to_base_on.read_restricted?
+        restricted = instance_to_base_on ? instance_to_base_on.read_restricted?  : false
       elsif based_on.is_a?(LinkedData::Models::Base)
         restricted = based_on.read_restricted?
       elsif based_on.is_a?(Symbol)
         instance_to_base_on = based_on.send(based_on)
-        restricted = instance_to_base_on.read_restricted?
+        restricted =  instance_to_base_on ? instance_to_base_on.read_restricted?  : false
       else
         restricted = false
       end


### PR DESCRIPTION
Fix a bug, when checking the access writes of a list of models; but one it depending models is nil (e.g ontologies with views) 