### PR TITLE
Fix: Archived submission space optimization

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -18,6 +18,7 @@ module LinkedData
       include SKOS::RootsFetcher
 
       FILES_TO_DELETE = ['labels.ttl', 'mappings.ttl', 'obsolete.ttl', 'owlapi.xrdf', 'errors.log']
+      FOLDERS_TO_DELETE = ['unzipped']
       FLAT_ROOTS_LIMIT = 1000
 
       model :ontology_submission, name_with: lambda { |s| submission_id_generator(s) }
@@ -757,6 +758,21 @@ module LinkedData
         submission_files.push(csv_path)
         submission_files.push(parsing_log_path) unless parsing_log_path.nil?
         FileUtils.rm(submission_files, force: true)
+
+        submission_folders = FOLDERS_TO_DELETE.map { |f| File.join(path_to_repo, f) }
+        submission_folders.each {|d| FileUtils.remove_dir(d) if File.directory?(d)}
+      end
+
+      def zip_submission_uploaded_file
+        self.bring(:uploadFilePath) if self.bring?(:uploadFilePath)
+
+        return self.uploadFilePath if zipped?
+        return self.uploadFilePath if self.uploadFilePath.nil? || self.uploadFilePath.empty?
+
+        old_path = self.uploadFilePath
+        new_path = Utils::FileHelpers.zip_file(old_path)
+        FileUtils.rm(old_path, force: true)
+        new_path
       end
 
       # accepts another submission in 'older' (it should be an 'older' ontology version)
@@ -1295,6 +1311,25 @@ eos
         return ready?(status: [:archived])
       end
 
+      def archive_submission
+        self.submissionStatus = nil
+        status = LinkedData::Models::SubmissionStatus.find("ARCHIVED").first
+        add_submission_status(status)
+
+        # Delete everything except for original ontology file.
+        ontology.bring(:submissions)
+        submissions = ontology.submissions
+        unless submissions.nil?
+          submissions.each { |s| s.bring(:submissionId) }
+          submission = submissions.sort { |a, b| b.submissionId <=> a.submissionId }[0]
+          # Don't perform deletion if this is the most recent submission.
+          if self.submissionId < submission.submissionId
+            delete_old_submission_files
+            self.uploadFilePath = zip_submission_uploaded_file
+          end
+        end
+      end
+
       ################################################################
       # Possible options with their defaults:
       #   process_rdf       = false
@@ -1363,21 +1398,7 @@ eos
           status = nil
 
           if archive
-            self.submissionStatus = nil
-            status = LinkedData::Models::SubmissionStatus.find("ARCHIVED").first
-            add_submission_status(status)
-
-            # Delete everything except for original ontology file.
-            ontology.bring(:submissions)
-            submissions = ontology.submissions
-            unless submissions.nil?
-              submissions.each { |s| s.bring(:submissionId) }
-              submission = submissions.sort { |a, b| b.submissionId <=> a.submissionId }[0]
-              # Don't perform deletion if this is the most recent submission.
-              if (self.submissionId < submission.submissionId)
-                delete_old_submission_files
-              end
-            end
+            archive_submission
           else
             if process_rdf
               # Remove processing status types before starting RDF parsing etc.

--- a/lib/ontologies_linked_data/utils/file.rb
+++ b/lib/ontologies_linked_data/utils/file.rb
@@ -14,7 +14,7 @@ module LinkedData
           self.name = gz.orig_name
         end
       end
-      
+
 
       def self.zip?(file_path)
         file_path = file_path.to_s
@@ -78,6 +78,21 @@ module LinkedData
           end
         end
         extracted_files
+      end
+
+      def self.zip_file(file_path)
+        return file_path if self.zip?(file_path)
+
+        zip_file_path = "#{file_path}.zip"
+        Zip::File.open(zip_file_path, Zip::File::CREATE) do |zipfile|
+          # Add the file to the zip
+          begin
+            zipfile.add(File.basename(file_path), file_path)
+          rescue Zip::EntryExistsError
+          end
+
+        end
+        zip_file_path
       end
 
       def self.automaster?(path, format)

--- a/lib/ontologies_linked_data/utils/file.rb
+++ b/lib/ontologies_linked_data/utils/file.rb
@@ -15,14 +15,6 @@ module LinkedData
         end
       end
       
-      def self.gzip?(file_path)
-        file_path = file_path.to_s
-        unless File.exist? file_path
-          raise ArgumentError, "File path #{file_path} not found"
-        end
-        file_type = `file --mime -b #{Shellwords.escape(file_path)}`
-        return file_type.split(";")[0] == "application/x-gzip"
-      end
 
       def self.zip?(file_path)
         file_path = file_path.to_s

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -362,6 +362,7 @@ eos
 
     # Process one prior to latest submission.  Some files should be deleted.
     old_sub = sorted_submissions.last
+    old_file_path = old_sub.uploadFilePath
     old_sub.process_submission(Logger.new(old_sub.parsing_log_path), parse_options)
     assert old_sub.archived?
 
@@ -382,6 +383,13 @@ eos
 
     assert_equal false, File.file?(old_sub.parsing_log_path),
       %-File deletion failed for '#{old_sub.parsing_log_path}'-
+
+    assert_equal false, File.file?(old_file_path),
+                 %-File deletion failed for '#{old_file_path}'-
+
+    assert old_sub.zipped?
+    assert File.file?(old_sub.uploadFilePath)
+
   end
 
   def test_submission_diff_across_ontologies

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -460,7 +460,7 @@ eos
     ontologyFile = "./test/data/ontology_files/pizza.owl.zip"
     archived_submission = nil
     2.times do |i|
-      id = 10 + i
+      id = 20 + i
       ont_submision =  LinkedData::Models::OntologySubmission.new({ :submissionId => id})
       assert (not ont_submision.valid?)
       assert_equal 4, ont_submision.errors.length


### PR DESCRIPTION
### Context 
fix https://github.com/ontoportal-lirmm/ontologies_linked_data/issues/42
follow up on this https://github.com/ncbo/ontologies_linked_data/pull/144

Now with this PR, a submission is archived we have two new behaviors 

1. Zip the archived submission uploaded file  and save in the attribute `uploadedFilePath` the new zipped file 
2. If the archived submission is zipped, remove the unzipped folder 