### PR TITLE
Feature: Add request all languages unit test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: c3456c45c12ed92d4a3ae43cac7c1d4cdbf290b6
+  revision: 10722bee64d970d534b90e7aaf71a4f5d34d98f0
   branch: development
   specs:
     goo (0.0.2)
@@ -36,18 +36,18 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ansi (1.5.0)
     ast (2.4.2)
-    bcrypt (3.1.18)
+    bcrypt (3.1.19)
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
-    connection_pool (2.4.0)
+    connection_pool (2.4.1)
     cube-ruby (0.0.3)
     daemons (1.4.1)
     date (3.3.3)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    email_spec (2.2.1)
+    email_spec (2.2.2)
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.7)
@@ -85,6 +85,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     json_pure (2.6.3)
+    language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
     libxml-ruby (2.9.0)
@@ -110,7 +111,7 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.3.0)
     net-http-persistent (2.9.4)
-    net-imap (0.3.4)
+    net-imap (0.3.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -124,8 +125,9 @@ GEM
     omni_logger (0.1.4)
       logger
     parallel (1.23.0)
-    parser (3.2.2.1)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
+      racc
     pony (1.13.1)
       mail (>= 2.0)
     powerbar (2.0.1)
@@ -133,7 +135,8 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
+    racc (1.7.1)
     rack (1.6.13)
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
@@ -145,7 +148,7 @@ GEM
       redis-client (>= 0.9.0)
     redis-client (0.14.1)
       connection_pool
-    regexp_parser (2.8.0)
+    regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
     rest-client (2.1.0)
@@ -156,17 +159,18 @@ GEM
     rexml (3.2.5)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rubocop (1.50.2)
+    rubocop (1.54.2)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
+    rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
@@ -188,7 +192,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thread_safe (0.3.6)
-    timeout (0.3.2)
+    timeout (0.4.0)
     tzinfo (0.3.62)
     unf (0.1.4)
       unf_ext
@@ -199,6 +203,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   activesupport (~> 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: 10722bee64d970d534b90e7aaf71a4f5d34d98f0
+  revision: 81ce88c6e52f34f9ef5c9ec88abd725c23d1b43a
   branch: development
   specs:
     goo (0.0.2)
@@ -85,7 +85,6 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     json_pure (2.6.3)
-    language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
     libxml-ruby (2.9.0)
@@ -159,11 +158,10 @@ GEM
     rexml (3.2.5)
     rsolr (1.1.2)
       builder (>= 2.1.2)
-    rubocop (1.54.2)
+    rubocop (1.50.2)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)

--- a/lib/ontologies_linked_data/models/class.rb
+++ b/lib/ontologies_linked_data/models/class.rb
@@ -283,9 +283,9 @@ module LinkedData
       BAD_PROPERTY_URIS = LinkedData::Mappings.mapping_predicates.values.flatten + ['http://bioportal.bioontology.org/metadata/def/prefLabel']
       EXCEPTION_URIS = ["http://bioportal.bioontology.org/ontologies/umls/cui"]
       BLACKLIST_URIS = BAD_PROPERTY_URIS - EXCEPTION_URIS
-      def properties
-        return nil if self.unmapped.nil?
-        properties = self.unmapped
+      def properties(*args)
+        return nil if self.unmapped(*args).nil?
+        properties = self.unmapped(*args)
         BLACKLIST_URIS.each {|bad_iri| properties.delete(RDF::URI.new(bad_iri))}
         properties
       end

--- a/lib/ontologies_linked_data/monkeypatches/object.rb
+++ b/lib/ontologies_linked_data/monkeypatches/object.rb
@@ -262,7 +262,7 @@ class Object
 
       next unless self.respond_to?(attribute)
       begin
-        hash[attribute] = self.send(attribute, :show_with_language)
+        hash[attribute] = self.send(attribute, show_languages: true)
       rescue Goo::Base::AttributeNotLoaded
         next
       rescue ArgumentError

--- a/test/models/test_class_portal_lang.rb
+++ b/test/models/test_class_portal_lang.rb
@@ -1,5 +1,5 @@
 require_relative './test_ontology_common'
-class TestClassMainLang < LinkedData::TestOntologyCommon
+class TestClassPortalLang < LinkedData::TestOntologyCommon
 
   def self.before_suite
     @@old_main_languages = Goo.main_languages
@@ -24,7 +24,7 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
     cls = parse_and_get_class lang: [:ES]
     cls.bring :unmapped
     LinkedData::Models::Class.map_attributes(cls)
-    assert_equal ['material detailed entity', 'entité matérielle detaillée'], cls.label
+    assert_empty cls.label
     assert_equal 'skos prefLabel rien', cls.prefLabel
     assert_equal ['entita esp', 'entite rien'], cls.synonym
   end
@@ -33,7 +33,7 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
     cls = parse_and_get_class lang: %i[ES FR]
     cls.bring :unmapped
     LinkedData::Models::Class.map_attributes(cls)
-    assert_equal ['entité matérielle detaillée'], cls.label
+    assert_empty cls.label
     assert_equal 'skos prefLabel rien', cls.prefLabel
     assert_equal ['entita esp', 'entite rien'], cls.synonym
   end
@@ -49,16 +49,17 @@ class TestClassMainLang < LinkedData::TestOntologyCommon
   def test_label_main_lang_not_found
     cls = parse_and_get_class lang: [:ES]
 
-    assert_equal ['material detailed entity', 'entité matérielle detaillée'], cls.label
+    assert_empty cls.label
     assert_equal 'skos prefLabel rien', cls.prefLabel
     assert_equal ['entita esp' , 'entite rien' ], cls.synonym
   end
 
   def test_label_secondary_lang
-    # 'es' will not be found so will take 'fr' if fond or anything else
+    # This feature is obsolete with the request language feature
+    # 'es' will not be found
     cls = parse_and_get_class lang: %i[ES FR]
 
-    assert_equal ['entité matérielle detaillée'], cls.label
+    assert_empty cls.label
     assert_equal 'skos prefLabel rien', cls.prefLabel
     assert_equal ['entita esp', 'entite rien'], cls.synonym
   end

--- a/test/models/test_class_portal_lang.rb
+++ b/test/models/test_class_portal_lang.rb
@@ -4,11 +4,19 @@ class TestClassPortalLang < LinkedData::TestOntologyCommon
   def self.before_suite
     @@old_main_languages = Goo.main_languages
     RequestStore.store[:requested_lang] = nil
+    parse
   end
 
   def self.after_suite
     Goo.main_languages = @@old_main_languages
     RequestStore.store[:requested_lang] = nil
+  end
+
+  def self.parse
+    new('').submission_parse('AGROOE', 'AGROOE Test extract metadata ontology',
+                              './test/data/ontology_files/agrooeMappings-05-05-2016.owl', 1,
+                              process_rdf: true, index_search: false,
+                              run_metrics: false, reasoning: true)
   end
 
   def test_map_attribute_found
@@ -76,11 +84,6 @@ class TestClassPortalLang < LinkedData::TestOntologyCommon
 
   def parse_and_get_class(lang:, klass: 'http://lirmm.fr/2015/resource/AGROOE_c_03')
     portal_lang_set portal_languages: lang
-    submission_parse('AGROOE', 'AGROOE Test extract metadata ontology',
-                     './test/data/ontology_files/agrooeMappings-05-05-2016.owl', 1,
-                     process_rdf: true, index_search: false,
-                     run_metrics: false, reasoning: true)
-
 
     cls = get_class(klass,'AGROOE')
     assert !cls.nil?
@@ -94,9 +97,6 @@ class TestClassPortalLang < LinkedData::TestOntologyCommon
     RequestStore.store[:requested_lang] = nil
   end
 
-  def get_ontology_last_submission(ont)
-    LinkedData::Models::Ontology.find(ont).first.latest_submission()
-  end
 
   def get_class(cls, ont)
     sub = LinkedData::Models::Ontology.find(ont).first.latest_submission()

--- a/test/models/test_class_request_lang.rb
+++ b/test/models/test_class_request_lang.rb
@@ -61,6 +61,33 @@ class TestClassRequestedLang < LinkedData::TestOntologyCommon
     assert_empty properties.select { |x| x.to_s['prefLabel'] }.values
   end
 
+  def test_request_all_languages
+
+    cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
+                            requested_lang: :ALL)
+
+    pref_label_all_languages = { en: 'industrialization', fr: 'industrialisation' }
+    assert_includes pref_label_all_languages.values, cls.prefLabel
+    assert_equal pref_label_all_languages, cls.prefLabel(show_languages: true)
+
+    synonym_all_languages = { en: ['industrial development'], fr: ['développement industriel'] }
+
+    assert_equal synonym_all_languages.values.flatten.sort, cls.synonym.sort
+    assert_equal synonym_all_languages, cls.synonym(show_languages: true)
+
+    properties = cls.properties
+
+    assert_equal synonym_all_languages.values.flatten.sort, properties.select { |x| x.to_s['altLabel'] }.values.first.map(&:to_s).sort
+    assert_equal pref_label_all_languages.values.sort, properties.select { |x| x.to_s['prefLabel'] }.values.first.map(&:to_s).sort
+
+    properties = cls.properties(show_languages: true)
+
+    assert_equal synonym_all_languages.stringify_keys,
+                 properties.select { |x| x.to_s['altLabel'] }.values.first.transform_values{|v| v.map(&:object)}
+    assert_equal pref_label_all_languages.stringify_keys,
+                 properties.select { |x| x.to_s['prefLabel'] }.values.first.transform_values{|v| v.first.object}
+  end
+
   private
 
   def lang_set(requested_lang: nil, portal_languages: nil)

--- a/test/models/test_class_request_lang.rb
+++ b/test/models/test_class_request_lang.rb
@@ -3,10 +3,11 @@ require 'request_store'
 
 class TestClassRequestedLang < LinkedData::TestOntologyCommon
 
-
   def self.before_suite
     @@old_main_languages = Goo.main_languages
     RequestStore.store[:requested_lang] = nil
+
+    parse
   end
 
   def self.after_suite
@@ -14,9 +15,19 @@ class TestClassRequestedLang < LinkedData::TestOntologyCommon
     RequestStore.store[:requested_lang] = nil
   end
 
+  def self.parse
+    new('').submission_parse('INRAETHES', 'Testing skos',
+                             'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos', 1,
+                             process_rdf: true, index_search: false,
+                             run_metrics: false, reasoning: false
+    )
+  end
+
+  def teardown
+    reset_lang
+  end
 
   def test_requested_language_found
-    parse
 
     cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
                             requested_lang: :FR)
@@ -36,11 +47,9 @@ class TestClassRequestedLang < LinkedData::TestOntologyCommon
     assert_equal ['industrial development'], properties.select { |x| x.to_s['altLabel'] }.values.first.map(&:to_s)
     assert_equal ['industrialization'], properties.select { |x| x.to_s['prefLabel'] }.values.first.map(&:to_s)
 
-    reset_lang
   end
 
   def test_requested_language_not_found
-    parse
 
     cls = get_class_by_lang('http://opendata.inrae.fr/thesaurusINRAE/c_22817',
                             requested_lang: :ES)
@@ -50,19 +59,9 @@ class TestClassRequestedLang < LinkedData::TestOntologyCommon
     properties = cls.properties
     assert_empty properties.select { |x| x.to_s['altLabel'] }.values
     assert_empty properties.select { |x| x.to_s['prefLabel'] }.values
-
-    reset_lang
   end
 
   private
-
-  def parse
-    submission_parse('INRAETHES', 'Testing skos',
-                     'test/data/ontology_files/thesaurusINRAE_nouv_structure.skos',
-                     1,
-                     process_rdf: true, index_search: false,
-                     run_metrics: false, reasoning: false)
-  end
 
   def lang_set(requested_lang: nil, portal_languages: nil)
     Goo.main_languages = portal_languages if portal_languages


### PR DESCRIPTION
### Context
This PR adds the final modifications and tests for the Multilingual topic (https://github.com/agroportal/project-management/issues/307) done in the PRs below: 

- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/91 
- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/85
- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/83 
- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/80 
- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/73 
- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/71
- https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/67 

### Changes

- Fix the class portal language test for the new multilingual support (https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/93/commits/e1b9af7a7ba6877554d58c3d8145ef55c21ec3e9)
   - Now when we ask a language we ether the values with the matching language, or nil or empty if not. Before we had a fallback to show the values in the other languages to not have empty fields 
- Fix SKOS Xl tests after the new multilingual support (https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/93/commits/6825393c658609dafee9638df9ae31e35b173f89)
  - SKOS XL labels are tagged with a language so the literal value is empty if it does not match the requested language  but the object is still fetched and showed
- Optimize request and portal lang tests by parsing the test ontology once](https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/93/commits/09a3f4884946b261c5dcf15fd3be2285e3afa84d)
- Add test request all languages unit test](https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/93/commits/56b88e6ec66887ee783d0263e9c80800b000ab98)
- Use the new getters argument to show languages](https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/93/commits/707b69d37ac3d692bed0e466474d015d0aa64c57)

