### PR TITLE
Fix: latest RDF version replaced RDF::SKOS with RDF::Vocab::SKOS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,14 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/goo.git
-  revision: f1a452ef7728f36719d3f5ddd869e67e2a768ff9
+  revision: b216f302cd53dc6c774762769a4fa5b475af99a1
   branch: development
   specs:
     goo (0.0.2)
-      addressable (~> 2.8)
       pry
-      rdf (= 1.0.8)
+      rdf (= 3.2.11)
+      rdf-raptor
+      rdf-rdfxml
+      rdf-vocab
       redis
       rest-client
       rsolr
@@ -36,13 +38,14 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ansi (1.5.0)
     ast (2.4.2)
+    base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.6)
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    crack (0.4.6)
+    crack (1.0.0)
       bigdecimal
       rexml
     cube-ruby (0.0.3)
@@ -89,11 +92,13 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     json_pure (2.7.1)
-    jwt (2.7.1)
+    jwt (2.8.0)
+      base64
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
     libxml-ruby (2.9.0)
+    link_header (0.0.8)
     logger (1.6.0)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
@@ -105,7 +110,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.1205)
+    mime-types-data (3.2024.0206)
     mini_mime (1.1.5)
     minitest (4.7.5)
     minitest-reporters (0.14.24)
@@ -114,9 +119,9 @@ GEM
       minitest (>= 2.12, < 5.0)
       powerbar
     multi_json (1.15.0)
-    multipart-post (2.3.0)
+    multipart-post (2.4.0)
     net-http-persistent (2.9.4)
-    net-imap (0.4.9.1)
+    net-imap (0.4.10)
       date
       net-protocol
     net-pop (0.1.2)
@@ -147,14 +152,27 @@ GEM
       rack (>= 1.0, < 3)
     rainbow (3.1.1)
     rake (10.5.0)
-    rdf (1.0.8)
-      addressable (>= 2.2)
-    redis (5.0.8)
+    rdf (3.2.11)
+      link_header (~> 0.0, >= 0.0.8)
+    rdf-raptor (3.2.0)
+      ffi (~> 1.15)
+      rdf (~> 3.2)
+    rdf-rdfxml (3.2.2)
+      builder (~> 3.2)
+      htmlentities (~> 4.3)
+      rdf (~> 3.2)
+      rdf-xsd (~> 3.2)
+    rdf-vocab (3.2.7)
+      rdf (~> 3.2, >= 3.2.4)
+    rdf-xsd (3.2.1)
+      rdf (~> 3.2)
+      rexml (~> 3.2)
+    redis (5.1.0)
       redis-client (>= 0.17.0)
-    redis-client (0.19.1)
+    redis-client (0.20.0)
       connection_pool
     regexp_parser (2.9.0)
-    request_store (1.5.1)
+    request_store (1.6.0)
       rack (>= 1.4)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -202,7 +220,7 @@ GEM
     unicode-display_width (2.5.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
-    webmock (3.19.1)
+    webmock (3.21.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/lib/ontologies_linked_data/concerns/ontology_submissions/skos/skos_submission_roots.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/skos/skos_submission_roots.rb
@@ -42,7 +42,7 @@ module LinkedData
 
         def roots_by_has_top_concept(concept_schemes, page, paged, pagesize)
           query_body = <<-eos
-            ?x #{RDF::SKOS[:hasTopConcept].to_ntriples} ?root .
+            ?x #{RDF::Vocab::SKOS[:hasTopConcept].to_ntriples} ?root .
             #{concept_schemes_filter(concept_schemes)}
           eos
           roots_by_query query_body, page, paged, pagesize
@@ -50,7 +50,7 @@ module LinkedData
 
         def roots_by_top_concept_of(concept_schemes, page, paged, pagesize)
           query_body = <<-eos
-            ?root #{RDF::SKOS[:topConceptOf].to_ntriples}  ?x.
+            ?root #{RDF::Vocab::SKOS[:topConceptOf].to_ntriples}  ?x.
             #{concept_schemes_filter(concept_schemes)}
           eos
           roots_by_query query_body, page, paged, pagesize

--- a/lib/ontologies_linked_data/models/ontology_format.rb
+++ b/lib/ontologies_linked_data/models/ontology_format.rb
@@ -39,14 +39,14 @@ module LinkedData
           return Goo.vocabulary(:metadata)[:treeView]
         end
         if skos?
-          return RDF::SKOS[:broader]
+          return RDF::Vocab::SKOS[:broader]
         end
         return RDF::RDFS[:subClassOf]
       end
 
       def class_type
         if skos?
-          return RDF::SKOS[:Concept]
+          return RDF::Vocab::SKOS[:Concept]
         end
         return RDF::OWL[:Class]
       end

--- a/lib/ontologies_linked_data/models/skos/collection.rb
+++ b/lib/ontologies_linked_data/models/skos/collection.rb
@@ -4,7 +4,7 @@ module LinkedData
       class Collection < LinkedData::Models::Base
 
         model :collection, name_with: :id, collection: :submission,
-                           namespace: :skos, schemaless: :true, rdf_type: ->(*x) { RDF::SKOS[:Collection] }
+                           namespace: :skos, schemaless: :true, rdf_type: ->(*x) { RDF::Vocab::SKOS[:Collection] }
 
         attribute :prefLabel, namespace: :skos, enforce: [:existence]
         attribute :member, namespace: :skos, enforce: [:list, :class]

--- a/lib/ontologies_linked_data/models/skos/scheme.rb
+++ b/lib/ontologies_linked_data/models/skos/scheme.rb
@@ -4,7 +4,7 @@ module LinkedData
       class Scheme < LinkedData::Models::Base
 
         model :scheme, name_with: :id, collection: :submission,
-              namespace: :skos, schemaless: :true, rdf_type: ->(*x) { RDF::SKOS[:ConceptScheme] }
+              namespace: :skos, schemaless: :true, rdf_type: ->(*x) { RDF::Vocab::SKOS[:ConceptScheme] }
 
         attribute :prefLabel, namespace: :skos, enforce: [:existence]
 

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -134,7 +134,7 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
     roots.each do |root|
       q_broader = <<-eos
 SELECT ?children WHERE {
-  ?children #{RDF::SKOS[:broader].to_ntriples} #{root.id.to_ntriples} }
+  ?children #{RDF::Vocab::SKOS[:broader].to_ntriples} #{root.id.to_ntriples} }
 eos
       children_query = []
       Goo.sparql_query_client.query(q_broader).each_solution do |sol|

--- a/test/models/test_skos_submission.rb
+++ b/test/models/test_skos_submission.rb
@@ -43,7 +43,7 @@ class TestOntologySubmission < LinkedData::TestOntologyCommon
     roots.each do |root|
       q_broader = <<-eos
 SELECT ?children WHERE {
-  ?children #{RDF::SKOS[:broader].to_ntriples} #{root.id.to_ntriples} }
+  ?children #{RDF::Vocab::SKOS[:broader].to_ntriples} #{root.id.to_ntriples} }
       eos
       children_query = []
       Goo.sparql_query_client.query(q_broader).each_solution do |sol|


### PR DESCRIPTION
### Changes 
*  replaced usage of RDF::SKOS with RDF::Vocab::SKOS (https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/151f918c6f7378bea9bddcd3ac22848dbce7856b)