### PR TITLE
Fix: send note creation notification to also the admins

### DIFF
--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -25,6 +25,7 @@ module LinkedData
 
         note.relatedOntology.each do |ont|
           Notifier.notify_subscribed_separately subject, body, ont, 'NOTES'
+          Notifier.notify_mails_grouped subject, body, Notifier.support_mails + Notifier.admin_mails(ont)
         end
       end
 

--- a/lib/ontologies_linked_data/utils/notifier.rb
+++ b/lib/ontologies_linked_data/utils/notifier.rb
@@ -40,7 +40,7 @@ module LinkedData
       end
 
       def self.notify_administrators_grouped(subject, body, ontology)
-        notify_support_grouped subject, body, admin_mails(ontology)
+        notify_support_grouped subject, body
       end
 
       def self.notify_mails_separately(subject, body, mails)


### PR DESCRIPTION
fix https://github.com/agroportal/project-management/issues/456, by sending the note creation notification to ontologies admin in addition of the subscribed users