### PR TITLE
Merge to master: Release 2.5.2 - fix note broken link and no owl:Ontology resources parsing

### DIFF
--- a/bin/owlapi-wrapper.jar
+++ b/bin/owlapi-wrapper.jar
@@ -1,1 +1,1 @@
-./owlapi-wrapper-1.4.2.jar
+owlapi-wrapper-1.4.3.jar

--- a/lib/ontologies_linked_data/models/users/user.rb
+++ b/lib/ontologies_linked_data/models/users/user.rb
@@ -83,10 +83,11 @@ module LinkedData
           OntologySubmission.cache_collection_invalidate
         end
 
-        if args.include?(:send_notifications) && args[:send_notifications]
+        if args.first&.dig(:send_notifications)
           begin
-            LinkedData::Utils::Notifications.new_user(user)
-          rescue Exception => e
+            LinkedData::Utils::Notifications.new_user(self)
+          rescue StandardError => e
+            puts "Error on user creation notification: #{e.message}"
           end
         end
 

--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -10,11 +10,10 @@ module LinkedData
         note.relatedOntology.each { |o| o.bring(:name) if o.bring?(:name); o.bring(:subscriptions) if o.bring?(:subscriptions) }
         ontologies = note.relatedOntology.map { |o| o.name }.join(", ")
         # Fix the note URL when using replace_url_prefix (in another VM than NCBO)
-        if LinkedData.settings.replace_url_prefix == true
-          note_url = "http://#{LinkedData.settings.ui_host}/notes/#{CGI.escape(note.id.to_s.gsub("http://data.bioontology.org", LinkedData.settings.rest_url_prefix))}"
-        else
-          note_url = "http://#{LinkedData.settings.ui_host}/notes/#{CGI.escape(note.id.to_s)}"
-        end
+
+        note_hash = note.id.to_s.split('/').last
+        note_url = "http://#{LinkedData.settings.ui_host}/notes/#{note_hash}"
+
         subject = "[#{LinkedData.settings.ui_name} Notes] [#{ontologies}] #{note.subject}"
         body = NEW_NOTE.gsub("%username%", note.creator.username)
                        .gsub("%ontologies%", ontologies)

--- a/test/models/test_ontology.rb
+++ b/test/models/test_ontology.rb
@@ -153,7 +153,8 @@ class TestOntology < LinkedData::TestOntologyCommon
     ont.bring(:submissions)
     sub = ont.submissions[0]
     props = ont.properties()
-    assert_equal 83, props.length
+    #assert_equal 83, props.length
+    assert_equal 79, props.length
 
     # verify sorting
     assert_equal "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#AlgorithmPurpose", props[0].id.to_s
@@ -192,7 +193,8 @@ class TestOntology < LinkedData::TestOntologyCommon
 
     # test property roots
     pr = ont.property_roots(sub, extra_include=[:hasChildren, :children])
-    assert_equal 62, pr.length
+    #assert_equal 62, pr.length
+    assert_equal 58, pr.length
 
     # verify sorting
     assert_equal "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#AlgorithmPurpose", pr[0].id.to_s
@@ -206,7 +208,8 @@ class TestOntology < LinkedData::TestOntologyCommon
     assert_equal 33, dpr.length
     # count annotation properties
     apr = pr.select { |p| p.class == LinkedData::Models::AnnotationProperty }
-    assert_equal 11, apr.length
+    #assert_equal 11, apr.length
+    assert_equal 7, apr.length
     # check for non-root properties
     assert_empty pr.select { |p| ["http://www.w3.org/2004/02/skos/core#broaderTransitive",
                   "http://www.w3.org/2004/02/skos/core#topConceptOf",

--- a/test/models/test_ontology_submission.rb
+++ b/test/models/test_ontology_submission.rb
@@ -423,7 +423,8 @@ SELECT DISTINCT * WHERE {
                      "./test/data/ontology_files/BRO_v3.5.owl", 1,
                      process_rdf: true, extract_metadata: false, index_properties: true)
     res = LinkedData::Models::OntologyProperty.search("*:*", {:fq => "submissionAcronym:\"BRO\"", :start => 0, :rows => 80})
-    assert_includes [81, 52] , res["response"]["numFound"] # if 81 if owlapi import skos properties
+    #assert_equal 81, res["response"]["numFound"] # if 81 if owlapi import skos properties
+    assert_equal 77, res["response"]["numFound"] # if 81 if owlapi import skos properties
     found = 0
 
     res["response"]["docs"].each do |doc|


### PR DESCRIPTION
### Changes
* https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/138
* [feature: use latest version of owlapi wrapper v1.4.3](https://github.com/ontoportal-lirmm/ontologies_linked_data/commit/c94c8fce0a1cd5d8e5367ea60e8f870cb3abff1a)
* https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/140
