### PR TITLE
Feature: Make notes url open in the ontology notes interface instead of a separate page

### DIFF
--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -10,8 +10,8 @@ module LinkedData
         note.relatedOntology.each { |o| o.bring(:name) if o.bring?(:name); o.bring(:subscriptions) if o.bring?(:subscriptions) }
         ontologies = note.relatedOntology.map { |o| o.name }.join(", ")
         # Fix the note URL when using replace_url_prefix (in another VM than NCBO)
-
-        note_url = "http://#{LinkedData.settings.ui_host}/ontologies/#{note.relatedOntology.first.acronym}?p=notes"
+        note_hash = note.id.to_s.split('/').last
+        note_url = "http://#{LinkedData.settings.ui_host}/ontologies/#{note.relatedOntology.first.acronym}?p=notes&noteid=#{note_hash}"
 
         subject = "[#{LinkedData.settings.ui_name} Notes] [#{ontologies}] #{note.subject}"
         body = NEW_NOTE.gsub("%username%", note.creator.username)

--- a/lib/ontologies_linked_data/utils/notifications.rb
+++ b/lib/ontologies_linked_data/utils/notifications.rb
@@ -11,8 +11,7 @@ module LinkedData
         ontologies = note.relatedOntology.map { |o| o.name }.join(", ")
         # Fix the note URL when using replace_url_prefix (in another VM than NCBO)
 
-        note_hash = note.id.to_s.split('/').last
-        note_url = "http://#{LinkedData.settings.ui_host}/notes/#{note_hash}"
+        note_url = "http://#{LinkedData.settings.ui_host}/ontologies/#{note.relatedOntology.first.acronym}?p=notes"
 
         subject = "[#{LinkedData.settings.ui_name} Notes] [#{ontologies}] #{note.subject}"
         body = NEW_NOTE.gsub("%username%", note.creator.username)
@@ -201,8 +200,8 @@ The %ui_name% Team
 EOS
 
       REST_PASSWORD = <<~HTML
-        Someone has requested a password reset for user %username% . If this was 
-        you, please click on the link below to reset your password. Otherwise, please 
+        Someone has requested a password reset for user %username% . If this was
+        you, please click on the link below to reset your password. Otherwise, please
         ignore this email.<br/><br/>
 
         <a href="%password_url%">%password_url%</a><br/><br/>


### PR DESCRIPTION
### Changes
Change the notes URL that we send in the notes emails from this from: `/notes/note_hash` to `/ontologies/ontology_acronym?p=notes` 