### PR TITLE
Fix: remove enforced values of agents type (person | organization) in submissions agents

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -81,12 +81,12 @@ module LinkedData
 
       # Person and organizations metadata
       attribute :contact, type: %i[contact list], enforce: [:existence]
-      attribute :hasCreator, namespace: :omv, type: %i[list Agent], enforce: [:is_person]
-      attribute :hasContributor, namespace: :omv, type: %i[list Agent], enforce: [:is_person]
+      attribute :hasCreator, namespace: :omv, type: %i[list Agent]
+      attribute :hasContributor, namespace: :omv, type: %i[list Agent]
       attribute :curatedBy, namespace: :pav, type: %i[list Agent]
       attribute :publisher, namespace: :dct, type: %i[list Agent]
-      attribute :fundedBy, namespace: :foaf, type: %i[list Agent], enforce: [:is_organization]
-      attribute :endorsedBy, namespace: :omv, type: %i[list Agent], enforce: [:is_organization]
+      attribute :fundedBy, namespace: :foaf, type: %i[list Agent]
+      attribute :endorsedBy, namespace: :omv, type: %i[list Agent]
       attribute :translator, namespace: :schema, type: %i[list Agent]
 
       # Community metadata


### PR DESCRIPTION
# Changes
Remove enforced values for the attributes:
- hasCreator
- hasContributor
- fundedBy
- endorsedBy

# How I tested the solution
I created an ontology and a submission for it,
filled the attributes with the wrong type of agents:
![image](https://github.com/user-attachments/assets/b27adadd-120d-4104-a74b-3dfa34225ace)

Then I saved it to see if it's valid or not, before removing the enforcings:
![image](https://github.com/user-attachments/assets/0eb7508e-d452-47e7-9373-05e13b670470)

After removing the enforcings it's valid:
![image](https://github.com/user-attachments/assets/c9506728-15c9-4dac-a87e-8c323c8c0aac)
