### PR TITLE
Fix: change dataDump default value to not use the rdf version

### DIFF
--- a/lib/ontologies_linked_data/concerns/ontology_submissions/submission_validators.rb
+++ b/lib/ontologies_linked_data/concerns/ontology_submissions/submission_validators.rb
@@ -290,7 +290,7 @@ module LinkedData
         end
 
         def data_dump_default(sub)
-          RDF::URI.new("#{LinkedData.settings.rest_url_prefix}ontologies/#{sub.ontology.acronym}/download?download_format=rdf")
+          RDF::URI.new("#{LinkedData.settings.rest_url_prefix}ontologies/#{sub.ontology.acronym}/download")
         end
 
         def csv_dump_default(sub)


### PR DESCRIPTION
fix https://github.com/agroportal/project-management/issues/526