### PR TITLE
Feature: Add portal configuration model reading from config file

### DIFF
--- a/config/config.rb.sample
+++ b/config/config.rb.sample
@@ -95,7 +95,7 @@ begin
 
     config.ui_name                       = 'Bioportal'
     config.title                         = 'NCBO BioPortal'
-    config.description                   = "The world's most comprehensive repository of biomedical ontologies "
+    config.description                   = "The world's most comprehensive repository of biomedical ontologies"
     config.color                         = '#234979'
     config.logo                          = ''
     config.fundedBy                      = [

--- a/config/config.rb.sample
+++ b/config/config.rb.sample
@@ -92,6 +92,38 @@ begin
         link: 'https://www.googleapis.com/oauth2/v3/userinfo'
       }
     }
+
+    config.ui_name                       = 'Bioportal'
+    config.title                         = 'NCBO BioPortal'
+    config.description                   = "The world's most comprehensive repository of biomedical ontologies "
+    config.color                         = '#234979'
+    config.logo                          = ''
+    config.fundedBy                      = [
+        {
+          img_src: 'https://identity.stanford.edu/wp-content/uploads/sites/3/2020/07/block-s-right.png',
+          url: 'https://www.stanford.edu',
+
+        },
+        {
+          img_src: 'https://ontoportal.org/images/logo.png',
+          url: 'https://ontoportal.org/',
+        }
+    ]
+    config.federated_portals = {
+          'agroportal' => {
+            api: 'http://data.agroportal.lirmm.fr',
+            ui: 'http://agroportal.lirmm.fr',
+            apikey: '1cfae05f-9e67-486f-820b-b393dec5764b',
+            color: '#1e2251'
+          },
+          'bioportal' => {
+                  api: 'http://data.bioontology.org',
+                  ui: 'http://bioportal.bioontology.org',
+                  apikey: '4a5011ea-75fa-4be6-8e89-f45c8c84844e',
+                  color: '#234979'
+           },
+
+    }
   end
 rescue NameError => e
   binding.pry

--- a/lib/ontologies_linked_data/config/config.rb
+++ b/lib/ontologies_linked_data/config/config.rb
@@ -42,9 +42,16 @@ module LinkedData
     # ###
 
     @settings.ui_name                       ||= 'Bioportal'
+    @settings.title                         ||= ''
+    @settings.description                   ||= ''
+    @settings.color                         ||= ''
+    @settings.logo                          ||= ''
+    @settings.fundedBy                      ||= {}
+    @settings.federated_portals             ||= {}
+
     @settings.ui_host                       ||= 'bioportal.bioontology.org'
-    @settings.replace_url_prefix             ||= false
-    @settings.id_url_prefix                  ||= DEFAULT_PREFIX
+    @settings.replace_url_prefix            ||= false
+    @settings.id_url_prefix                 ||= DEFAULT_PREFIX
     @settings.queries_debug                 ||= false
     @settings.enable_monitoring             ||= false
     @settings.cube_host                     ||= 'localhost'

--- a/lib/ontologies_linked_data/models/portal_config.rb
+++ b/lib/ontologies_linked_data/models/portal_config.rb
@@ -8,8 +8,15 @@ module LinkedData
       attribute :description, namespace: :dcterms
       attribute :logo, namespace: :foaf, enforce: [:url]
       attribute :numberOfArtefacts, namespace: :mod, handler: :ontologies_count
-      attribute :federated_portals
-      attribute :fundedBy, enforce: [:list]
+      attribute :federated_portals, handler: :federated_portals_settings
+      attribute :fundedBy, namespace: :foaf, enforce: [:list]
+
+      serialize_default :acronym, :title, :color, :description, :logo, :numberOfArtefacts, :federated_portals, :fundedBy
+
+      def initialize(*args)
+        super
+        init_federated_portals_settings
+      end
 
       def self.current_portal_config
         p = LinkedData::Models::PortalConfig.new
@@ -20,29 +27,31 @@ module LinkedData
         p.color = LinkedData.settings.color
         p.logo = LinkedData.settings.logo
         p.fundedBy = LinkedData.settings.fundedBy
-        p.federated_portals = LinkedData.settings.federated_portals
         p
       end
 
+      def init_federated_portals_settings(federated_portals = nil)
+        @federated_portals = federated_portals || LinkedData.settings.federated_portals.symbolize_keys
+      end
+
+      def federated_portals_settings
+        @federated_portals
+      end
+
       def ontologies_count
-        if current_portal?
-          LinkedData::Models::Ontology.where(viewingRestriction: 'public').count
-        else
-          0
-        end
+        LinkedData::Models::Ontology.where(viewingRestriction: 'public').count
       end
 
       def self.valid_hash_code(inst, attr)
         inst.bring(attr) if inst.bring?(attr)
         str = inst.send(attr)
 
-        unless /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/ === str do
-          return [:valid_hash_code, "Invalid hex color code: '#{str}'. Please provide a valid hex code in the format '#FFF' or '#FFFFFF'."]
-        end
-        end
-
+        return if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/ === str)
+        [:valid_hash_code,
+         "Invalid hex color code: '#{str}'. Please provide a valid hex code in the format '#FFF' or '#FFFFFF'."]
       end
     end
   end
 end
+
 

--- a/lib/ontologies_linked_data/models/portal_config.rb
+++ b/lib/ontologies_linked_data/models/portal_config.rb
@@ -1,0 +1,48 @@
+module LinkedData
+  module Models
+    class PortalConfig < LinkedData::Models::Base
+      model :SemanticArtefactCatalogue, namespace: :mod, name_with: :acronym
+      attribute :acronym, enforce: [:unique, :existence]
+      attribute :title, namespace: :dcterms, enforce: [:existence]
+      attribute :color, enforce: [:existence, :valid_hash_code]
+      attribute :description, namespace: :dcterms
+      attribute :logo, namespace: :foaf, enforce: [:url]
+      attribute :numberOfArtefacts, namespace: :mod, handler: :ontologies_count
+      attribute :federated_portals
+      attribute :fundedBy, enforce: [:list]
+
+      def self.current_portal_config
+        p = LinkedData::Models::PortalConfig.new
+
+        p.acronym = LinkedData.settings.ui_name.downcase
+        p.title = LinkedData.settings.title
+        p.description = LinkedData.settings.description
+        p.color = LinkedData.settings.color
+        p.logo = LinkedData.settings.logo
+        p.fundedBy = LinkedData.settings.fundedBy
+        p.federated_portals = LinkedData.settings.federated_portals
+        p
+      end
+
+      def ontologies_count
+        if current_portal?
+          LinkedData::Models::Ontology.where(viewingRestriction: 'public').count
+        else
+          0
+        end
+      end
+
+      def self.valid_hash_code(inst, attr)
+        inst.bring(attr) if inst.bring?(attr)
+        str = inst.send(attr)
+
+        unless /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/ === str do
+          return [:valid_hash_code, "Invalid hex color code: '#{str}'. Please provide a valid hex code in the format '#FFF' or '#FFFFFF'."]
+        end
+        end
+
+      end
+    end
+  end
+end
+

--- a/test/models/test_portal_configuration.rb
+++ b/test/models/test_portal_configuration.rb
@@ -10,8 +10,6 @@ class TestPortalConfiguration < LinkedData::TestCase
                  color: '#234979',
                  description: "The world's most comprehensive repository of biomedical ontologies",
                  logo: '',
-                 federated_portals: { 'agroportal' => { api: 'http://data.agroportal.lirmm.fr', ui: 'http://agroportal.lirmm.fr', apikey: '1cfae05f-9e67-486f-820b-b393dec5764b', color: '#1e2251' },
-                                      'bioportal' => { api: 'http://data.bioontology.org', ui: 'http://bioportal.bioontology.org', apikey: '4a5011ea-75fa-4be6-8e89-f45c8c84844e', color: '#234979' } },
                  fundedBy: [{ img_src: 'https://identity.stanford.edu/wp-content/uploads/sites/3/2020/07/block-s-right.png', url: 'https://www.stanford.edu' },
                             { img_src: 'https://ontoportal.org/images/logo.png', url: 'https://ontoportal.org/' }],
                  id: RDF::URI.new('http://data.bioontology.org/SemanticArtefactCatalogues/bioportal') }
@@ -19,5 +17,11 @@ class TestPortalConfiguration < LinkedData::TestCase
     assert config.valid?
 
     assert_equal expected, config.to_hash
+
+    expected_federated_portals = { 'agroportal' => { api: 'http://data.agroportal.lirmm.fr', ui: 'http://agroportal.lirmm.fr', apikey: '1cfae05f-9e67-486f-820b-b393dec5764b', color: '#1e2251' },
+                                   'bioportal' => { api: 'http://data.bioontology.org', ui: 'http://bioportal.bioontology.org', apikey: '4a5011ea-75fa-4be6-8e89-f45c8c84844e', color: '#234979' } }.symbolize_keys
+    assert_equal expected_federated_portals, config.federated_portals
+    refute_nil config.numberOfArtefacts
   end
 end
+

--- a/test/models/test_portal_configuration.rb
+++ b/test/models/test_portal_configuration.rb
@@ -1,0 +1,23 @@
+require_relative '../test_case'
+
+class TestPortalConfiguration < LinkedData::TestCase
+
+  def test_read_portal_config
+    config = LinkedData::Models::PortalConfig.current_portal_config
+
+    expected = { acronym: 'bioportal',
+                 title: 'NCBO BioPortal',
+                 color: '#234979',
+                 description: "The world's most comprehensive repository of biomedical ontologies",
+                 logo: '',
+                 federated_portals: { 'agroportal' => { api: 'http://data.agroportal.lirmm.fr', ui: 'http://agroportal.lirmm.fr', apikey: '1cfae05f-9e67-486f-820b-b393dec5764b', color: '#1e2251' },
+                                      'bioportal' => { api: 'http://data.bioontology.org', ui: 'http://bioportal.bioontology.org', apikey: '4a5011ea-75fa-4be6-8e89-f45c8c84844e', color: '#234979' } },
+                 fundedBy: [{ img_src: 'https://identity.stanford.edu/wp-content/uploads/sites/3/2020/07/block-s-right.png', url: 'https://www.stanford.edu' },
+                            { img_src: 'https://ontoportal.org/images/logo.png', url: 'https://ontoportal.org/' }],
+                 id: RDF::URI.new('http://data.bioontology.org/SemanticArtefactCatalogues/bioportal') }
+
+    assert config.valid?
+
+    assert_equal expected, config.to_hash
+  end
+end


### PR DESCRIPTION
fix https://github.com/agroportal/project-management/issues/592, by adding a model to define the portal configuration, containing the following  attributes: 
```ruby
      model :SemanticArtefactCatalogue, namespace: :mod, name_with: :acronym
      attribute :acronym, enforce: [:unique, :existence]
      attribute :title, namespace: :dcterms, enforce: [:existence]
      attribute :color, enforce: [:existence, :valid_hash_code]
      attribute :description, namespace: :dcterms
      attribute :logo, namespace: :foaf, enforce: [:url]
      attribute :numberOfArtefacts, namespace: :mod, handler: :ontologies_count
      attribute :federated_portals
      attribute :fundedBy, enforce: [:list] 
```

the model is not saved in the triple store, but use the configuration files, to fill its attributes.

```ruby 
    config.ui_name                       = 'Bioportal'
    config.title                         = 'NCBO BioPortal'
    config.description                   = "The world's most comprehensive repository of biomedical ontologies "
    config.color                         = '#234979'
    config.logo                          = ''
    config.fundedBy                      = [
        {
          img_src: 'https://identity.stanford.edu/wp-content/uploads/sites/3/2020/07/block-s-right.png',
          url: 'https://www.stanford.edu',

        },
        {
          img_src: 'https://ontoportal.org/images/logo.png',
          url: 'https://ontoportal.org/',
        }
    ]
    config.federated_portals = {
          'agroportal' => {
            api: 'http://data.agroportal.lirmm.fr',
            ui: 'http://agroportal.lirmm.fr',
            apikey: 'XXXX',
            color: '#1e2251'
          },
          'bioportal' => {
                  api: 'http://data.bioontology.org',
                  ui: 'http://bioportal.bioontology.org',
                  apikey: 'XXXX',
                  color: '#234979'
           },

    }
```