### PR TITLE
Feature: Add mappings to `Ontologies` contextual API links

### DIFF
--- a/lib/ontologies_linked_data/models/ontology.rb
+++ b/lib/ontologies_linked_data/models/ontology.rb
@@ -78,6 +78,7 @@ module LinkedData
               LinkedData::Hypermedia::Link.new("views", lambda {|s| "ontologies/#{s.acronym}/views"}, self.type_uri),
               LinkedData::Hypermedia::Link.new("analytics", lambda {|s| "ontologies/#{s.acronym}/analytics"}, "#{Goo.namespaces[:metadata].to_s}Analytics"),
               LinkedData::Hypermedia::Link.new("agents", lambda {|s| "ontologies/#{s.acronym}/agents"}, LinkedData::Models::Agent.uri_type),
+              LinkedData::Hypermedia::Link.new("mappings", lambda {|s| "ontologies/#{s.acronym}/mappings"}, LinkedData::Models::Mapping.type_uri),
               LinkedData::Hypermedia::Link.new("ui", lambda {|s| "http://#{LinkedData.settings.ui_host}/ontologies/#{s.acronym}"}, self.uri_type)
 
       # Access control


### PR DESCRIPTION
Related [issue #134](https://github.com/ontoportal-lirmm/ontologies_linked_data/issues/134)

![mappings](https://github.com/user-attachments/assets/9344602c-b804-480d-9e6b-c3b75d8e3670)


Add mappings to `Ontologies` contextual API links