### PR TITLE
Fix : prevent serialization of attributes tagged as :serialize_never 

### DIFF
--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -46,7 +46,7 @@ module LinkedData
                           if attributes.first == :all
                             (self.attributes + self.hypermedia_settings[:serialize_default]).uniq
                           else
-                            attributes - self.hypermedia_settings[:serialize_never])
+                            attributes - self.hypermedia_settings[:serialize_never]
                           end
                         elsif self.hypermedia_settings[:serialize_default].empty?
                           self.attributes

--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -46,7 +46,7 @@ module LinkedData
                           if attributes.first == :all
                             (self.attributes + self.hypermedia_settings[:serialize_default]).uniq
                           else
-                            attributes
+                            attributes - self.hypermedia_settings[:serialize_never])
                           end
                         elsif self.hypermedia_settings[:serialize_default].empty?
                           self.attributes


### PR DESCRIPTION
Prevent showing sensitive data using that serialize_never helper in the Goo models.