### PR TITLE
Feature: Parent category multiple values

### DIFF
--- a/lib/ontologies_linked_data/models/category.rb
+++ b/lib/ontologies_linked_data/models/category.rb
@@ -6,7 +6,7 @@ module LinkedData
       attribute :name, enforce: [:existence]
       attribute :description
       attribute :created, enforce: [:date_time], default: lambda { |record| DateTime.now }
-      attribute :parentCategory, enforce: [:category]
+      attribute :parentCategories, enforce: [:category, :list]
       attribute :ontologies, inverse: { on: :ontology, attribute: :hasDomain }
 
       cache_timeout 86400

--- a/lib/ontologies_linked_data/models/category.rb
+++ b/lib/ontologies_linked_data/models/category.rb
@@ -6,7 +6,7 @@ module LinkedData
       attribute :name, enforce: [:existence]
       attribute :description
       attribute :created, enforce: [:date_time], default: lambda { |record| DateTime.now }
-      attribute :parentCategories, enforce: [:category, :list]
+      attribute :parentCategory, enforce: [:category, :list]
       attribute :ontologies, inverse: { on: :ontology, attribute: :hasDomain }
 
       cache_timeout 86400


### PR DESCRIPTION
### PR description
Make Category model accept multiple values for parent category instead of a single value.

### Source
**Email Christelle Pierkot**

> J'ai besoin par exemple que ma catégorie Atmosphere ait pour parents les categories Earth et Climate. D’après ce que j'ai vu, on ne peut assigner qu'un seul parent car c'est une liste déroulante qui est proposée.
