### PR TITLE
Feature: refactor mapping count module to simplify the code

### DIFF
--- a/lib/ontologies_linked_data/concerns/mappings/mapping_counts.rb
+++ b/lib/ontologies_linked_data/concerns/mappings/mapping_counts.rb
@@ -5,7 +5,7 @@ module LinkedData
         def mapping_counts(enable_debug = false, logger = nil, reload_cache = false, arr_acronyms = [])
           logger = nil unless enable_debug
           t = Time.now
-          latest = self.retrieve_latest_submissions(options = { acronyms: arr_acronyms })
+          latest = retrieve_latest_submissions({ acronyms: arr_acronyms })
           counts = {}
           # Counting for External mappings
           t0 = Time.now
@@ -34,12 +34,12 @@ module LinkedData
           end
           # Counting for mappings between the ontologies hosted by the BioPortal appliance
           i = 0
-          epr = Goo.sparql_query_client(:main)
+          Goo.sparql_query_client(:main)
 
           latest.each do |acro, sub|
-            self.handle_triple_store_downtime(logger) if Goo.backend_4s?
+            handle_triple_store_downtime(logger) if Goo.backend_4s?
             t0 = Time.now
-            s_counts = self.mapping_ontologies_count(sub, nil, reload_cache = reload_cache)
+            s_counts = mapping_ontologies_count(sub, nil, reload_cache = reload_cache)
             s_total = 0
 
             s_counts.each do |k, v|
@@ -63,7 +63,7 @@ module LinkedData
         end
 
         def create_mapping_counts(logger, arr_acronyms = [])
-          ont_msg = arr_acronyms.empty? ? "all ontologies" : "ontologies [#{arr_acronyms.join(', ')}]"
+          ont_msg = arr_acronyms.empty? ? 'all ontologies' : "ontologies [#{arr_acronyms.join(', ')}]"
 
           time = Benchmark.realtime do
             create_mapping_count_totals_for_ontologies(logger, arr_acronyms)
@@ -79,20 +79,20 @@ module LinkedData
         end
 
         def create_mapping_count_totals_for_ontologies(logger, arr_acronyms)
-          new_counts = mapping_counts(enable_debug = true, logger = logger, reload_cache = true, arr_acronyms)
+          new_counts = mapping_counts(true, logger, true, arr_acronyms)
           persistent_counts = {}
-          f = Goo::Filter.new(:pair_count) == false
 
-          LinkedData::Models::MappingCount.where.filter(f)
-                                          .include(:ontologies, :count)
+          LinkedData::Models::MappingCount.where(pair_count: false)
+                                          .include(:ontologies, :count, :pair_count)
                                           .include(:all)
                                           .all
                                           .each do |m|
             persistent_counts[m.ontologies.first] = m
           end
 
-          latest = self.retrieve_latest_submissions(options = { acronyms: arr_acronyms })
-          delete_zombie_mapping_count(persistent_counts.values, latest.values.compact.map { |sub| sub.ontology.acronym })
+          latest = retrieve_latest_submissions
+          delete_zombie_mapping_count(persistent_counts, latest, new_counts)
+
 
           num_counts = new_counts.keys.length
           ctr = 0
@@ -100,47 +100,9 @@ module LinkedData
           new_counts.each_key do |acr|
             new_count = new_counts[acr]
             ctr += 1
-
-            if persistent_counts.include?(acr)
-              inst = persistent_counts[acr]
-              if new_count.zero?
-                inst.delete if inst.persistent?
-              elsif new_count != inst.count
-                inst.bring_remaining
-                inst.count = new_count
-
-                begin
-                  if inst.valid?
-                    inst.save
-                  else
-                    logger.error("Error updating mapping count for #{acr}: #{inst.id.to_s}. #{inst.errors}")
-                    next
-                  end
-                rescue Exception => e
-                  logger.error("Exception updating mapping count for #{acr}: #{inst.id.to_s}. #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}")
-                  next
-                end
-              end
-            else
-              m = LinkedData::Models::MappingCount.new
-              m.ontologies = [acr]
-              m.pair_count = false
-              m.count = new_count
-
-              begin
-                if m.valid?
-                  m.save
-                else
-                  logger.error("Error saving new mapping count for #{acr}. #{m.errors}")
-                  next
-                end
-              rescue Exception => e
-                logger.error("Exception saving new mapping count for #{acr}. #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}")
-                next
-              end
-            end
+            update_mapping_count(persistent_counts, new_counts, acr, acr, new_count, false)
             remaining = num_counts - ctr
-            logger.info("Total mapping count saved for #{acr}: #{new_count}. " << ((remaining.positive?) ? "#{remaining} counts remaining..." : "All done!"))
+            logger.info("Total mapping count saved for #{acr}: #{new_count}. " << (remaining.positive? ? "#{remaining} counts remaining..." : 'All done!'))
           end
         end
 
@@ -148,23 +110,17 @@ module LinkedData
         # ontologies to ALL other ontologies in the system
         def create_mapping_count_pairs_for_ontologies(logger, arr_acronyms)
 
-          latest_submissions = self.retrieve_latest_submissions(options = { acronyms: arr_acronyms })
-          all_latest_submissions = self.retrieve_latest_submissions
+          latest_submissions = retrieve_latest_submissions({ acronyms: arr_acronyms })
+          all_latest_submissions = retrieve_latest_submissions
           ont_total = latest_submissions.length
           logger.info("There is a total of #{ont_total} ontologies to process...")
           ont_ctr = 0
-          # filename = 'mapping_pairs.ttl'
-          # temp_dir = Dir.tmpdir
-          # temp_file_path = File.join(temp_dir, filename)
-          # temp_dir = '/Users/mdorf/Downloads/test/'
-          # temp_file_path = File.join(File.dirname(file_path), "test.ttl")
-          # fsave = File.open(temp_file_path, "a")
+
           latest_submissions.each do |acr, sub|
-            self.handle_triple_store_downtime(logger) if Goo.backend_4s?
             new_counts = nil
 
             time = Benchmark.realtime do
-              new_counts = self.mapping_ontologies_count(sub, nil, reload_cache = true)
+              new_counts = mapping_ontologies_count(sub, nil, true)
             end
             logger.info("Retrieved new mapping pair counts for #{acr} in #{time} seconds.")
             ont_ctr += 1
@@ -176,61 +132,20 @@ module LinkedData
               persistent_counts[other] = m
             end
 
-            delete_zombie_mapping_count(persistent_counts.values, all_latest_submissions.values.compact.map { |s| s.ontology.acronym })
+            delete_zombie_mapping_count(persistent_counts, all_latest_submissions, new_counts)
+
 
             num_counts = new_counts.keys.length
             logger.info("Ontology: #{acr}. #{num_counts} mapping pair counts to record...")
-            logger.info("------------------------------------------------")
+            logger.info('------------------------------------------------')
             ctr = 0
 
             new_counts.each_key do |other|
               new_count = new_counts[other]
               ctr += 1
-
-              if persistent_counts.include?(other)
-                inst = persistent_counts[other]
-                if new_count.zero?
-                  inst.delete
-                elsif new_count != inst.count
-                  inst.bring_remaining if inst.persistent?
-                  inst.pair_count = true
-                  inst.count = new_count
-
-                  begin
-                    if inst.valid?
-                      inst.save()
-                      # inst.save({ batch: fsave })
-                    else
-                      logger.error("Error updating mapping count for the pair [#{acr}, #{other}]: #{inst.id.to_s}. #{inst.errors}")
-                      next
-                    end
-                  rescue Exception => e
-                    logger.error("Exception updating mapping count for the pair [#{acr}, #{other}]: #{inst.id.to_s}. #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}")
-                    next
-                  end
-                end
-              else
-                next unless new_counts.key?(other)
-
-                m = LinkedData::Models::MappingCount.new
-                m.count = new_count
-                m.ontologies = [acr, other]
-                m.pair_count = true
-                begin
-                  if m.valid?
-                    m.save()
-                    # m.save({ batch: fsave })
-                  else
-                    logger.error("Error saving new mapping count for the pair [#{acr}, #{other}]. #{m.errors}")
-                    next
-                  end
-                rescue Exception => e
-                  logger.error("Exception saving new mapping count for the pair [#{acr}, #{other}]. #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}")
-                  next
-                end
-              end
+              update_mapping_count(persistent_counts, new_counts, acr, other, new_count, true)
               remaining = num_counts - ctr
-              logger.info("Mapping count saved for the pair [#{acr}, #{other}]: #{new_count}. " << ((remaining.positive?) ? "#{remaining} counts remaining for #{acr}..." : "All done!"))
+              logger.info("Mapping count saved for the pair [#{acr}, #{other}]: #{new_count}. " << (remaining.positive? ? "#{remaining} counts remaining for #{acr}..." : 'All done!'))
               wait_interval = 250
 
               next unless (ctr % wait_interval).zero?
@@ -240,25 +155,43 @@ module LinkedData
               sleep(sec_to_wait)
             end
             remaining_ont = ont_total - ont_ctr
-            logger.info("Completed processing pair mapping counts for #{acr}. " << ((remaining_ont.positive?) ? "#{remaining_ont} ontologies remaining..." : "All ontologies processed!"))
+            logger.info("Completed processing pair mapping counts for #{acr}. " << (remaining_ont.positive? ? "#{remaining_ont} ontologies remaining..." : 'All ontologies processed!'))
           end
-          # fsave.close
         end
 
         private
 
-        def delete_zombie_mapping_count(existent_counts, submissions_ready)
-          special_mappings = ["http://data.bioontology.org/metadata/ExternalMappings",
-                              "http://data.bioontology.org/metadata/InterportalMappings/agroportal",
-                              "http://data.bioontology.org/metadata/InterportalMappings/ncbo",
-                              "http://data.bioontology.org/metadata/InterportalMappings/sifr"]
+        def update_mapping_count(persistent_counts, new_counts, acr, other, new_count, pair_count)
+          if persistent_counts.include?(other)
+            inst = persistent_counts[other]
+            if new_count.zero?
+              inst.delete
+            elsif new_count != inst.count
+              inst.pair_count = true
+              inst.count = new_count
+              inst.save
+            end
+          else
+            return unless new_counts.key?(other)
 
-          existent_counts.each do |mapping|
-            next if mapping.ontologies.size == 1 && !(mapping.ontologies & special_mappings).empty?
-            next if mapping.ontologies.all? { |x| submissions_ready.include?(x) }
-            next unless mapping.persistent?
+            m = LinkedData::Models::MappingCount.new
+            m.count = new_count
+            m.ontologies = if pair_count
+                             [acr, other]
+                           else
+                             [acr]
+                           end
+            m.pair_count = pair_count
+            m.save
+          end
+        end
 
-            mapping.delete
+        def delete_zombie_mapping_count(persistent_counts, all_latest_submissions, new_counts)
+          persistent_counts.each do |k, v|
+            next if all_latest_submissions.key?(k) && new_counts.key?(k)
+
+            v.delete
+            persistent_counts.delete(k)
           end
         end
       end

--- a/test/models/test_mappings.rb
+++ b/test/models/test_mappings.rb
@@ -1,5 +1,5 @@
-require_relative "./test_ontology_common"
-require "logger"
+require_relative './test_ontology_common'
+require 'logger'
 
 class TestMapping < LinkedData::TestOntologyCommon
 
@@ -16,20 +16,20 @@ class TestMapping < LinkedData::TestOntologyCommon
   def self.ontologies_parse
     helper = LinkedData::TestOntologyCommon.new(self)
     helper.submission_parse(ONT_ACR1,
-                            "MappingOntTest1",
-                            "./test/data/ontology_files/BRO_v3.3.owl", 11,
+                            'MappingOntTest1',
+                            './test/data/ontology_files/BRO_v3.3.owl', 11,
                             process_rdf: true, extract_metadata: false)
     helper.submission_parse(ONT_ACR2,
-                            "MappingOntTest2",
-                            "./test/data/ontology_files/CNO_05.owl", 22,
+                            'MappingOntTest2',
+                            './test/data/ontology_files/CNO_05.owl', 22,
                             process_rdf: true, extract_metadata: false)
     helper.submission_parse(ONT_ACR3,
-                            "MappingOntTest3",
-                            "./test/data/ontology_files/aero.owl", 33,
+                            'MappingOntTest3',
+                            './test/data/ontology_files/aero.owl', 33,
                             process_rdf: true, extract_metadata: false)
     helper.submission_parse(ONT_ACR4,
-                            "MappingOntTest4",
-                            "./test/data/ontology_files/fake_for_mappings.owl", 44,
+                            'MappingOntTest4',
+                            './test/data/ontology_files/fake_for_mappings.owl', 44,
                             process_rdf: true, extract_metadata: false)
   end
 
@@ -47,8 +47,8 @@ class TestMapping < LinkedData::TestOntologyCommon
     counts = LinkedData::Models::MappingCount.where.include(:ontologies).all.map(&:ontologies)
     refute(counts.any? { |x| x.include?(ONT_ACR4) }, 'Mapping count of deleted ontologies should not exist anymore')
     submission_parse(ONT_ACR4,
-                     "MappingOntTest4",
-                     "./test/data/ontology_files/fake_for_mappings.owl", 45,
+                     'MappingOntTest4',
+                     './test/data/ontology_files/fake_for_mappings.owl', 45,
                      process_rdf: true, extract_metadata: false)
   end
 
@@ -71,41 +71,62 @@ class TestMapping < LinkedData::TestOntologyCommon
 
     LinkedData::Models::Ontology.find(ONT_ACR4).first.delete
     submission_parse(ONT_ACR4,
-                     "MappingOntTest4",
-                     "./test/data/ontology_files/fake_for_mappings.owl", 46,
+                     'MappingOntTest4',
+                     './test/data/ontology_files/fake_for_mappings.owl', 46,
                      process_rdf: true, extract_metadata: false)
   end
+
 
   def test_mapping_count_models
     LinkedData::Models::MappingCount.where.all(&:delete)
 
     m = LinkedData::Models::MappingCount.new
     assert !m.valid?
-    m.ontologies = ["BRO"]
+    m.ontologies = ['BRO']
     m.pair_count = false
     m.count = 123
     assert m.valid?
     m.save
-    assert LinkedData::Models::MappingCount.where(ontologies: "BRO").all.count == 1
+    assert LinkedData::Models::MappingCount.where(ontologies: 'BRO').all.count == 1
     m = LinkedData::Models::MappingCount.new
     assert !m.valid?
-    m.ontologies = ["BRO", "FMA"]
+    m.ontologies = ['BRO', 'FMA']
     m.count = 321
     m.pair_count = true
     assert m.valid?
     m.save
-    assert LinkedData::Models::MappingCount.where(ontologies: "BRO").all.count == 2
-    result = LinkedData::Models::MappingCount.where(ontologies: "BRO")
-                                             .and(ontologies: "FMA").include(:count).all
+    assert LinkedData::Models::MappingCount.where(ontologies: 'BRO').all.count == 2
+    result = LinkedData::Models::MappingCount.where(ontologies: 'BRO')
+                                             .and(ontologies: 'FMA').include(:count).all
     assert result.length == 1
     assert result.first.count == 321
-    result = LinkedData::Models::MappingCount.where(ontologies: "BRO")
+    result = LinkedData::Models::MappingCount.where(ontologies: 'BRO')
                                              .and(pair_count: true)
                                              .include(:count)
                                              .all
     assert result.length == 1
     assert result.first.count == 321
     LinkedData::Models::MappingCount.where.all(&:delete)
+  end
+
+  def test_count_mapping_creation
+    LinkedData::Models::MappingCount.where.all(&:delete)
+    assert create_count_mapping > 2, 'Mapping count should exceed the value of 2'
+    assert_equal 12, LinkedData::Models::MappingCount.where.all.size
+
+    puts "run count mapping to #{ONT_ACR1} and #{ONT_ACR2}"
+    LinkedData::Mappings.create_mapping_counts(Logger.new(TestLogFile.new), [ONT_ACR1, ONT_ACR2])
+    assert_equal 12, LinkedData::Models::MappingCount.where.all.size
+
+    puts "run count mapping to only #{ONT_ACR1}"
+    LinkedData::Mappings.create_mapping_counts(Logger.new(TestLogFile.new), [ONT_ACR1])
+
+
+    assert_equal 12, LinkedData::Models::MappingCount.where.all.size
+
+    puts 'run count mapping to all ontologies'
+    LinkedData::Mappings.create_mapping_counts(Logger.new(TestLogFile.new))
+    assert_equal 12, LinkedData::Models::MappingCount.where.all.size
   end
 
   def test_mappings_ontology
@@ -130,23 +151,23 @@ class TestMapping < LinkedData::TestOntologyCommon
       mappings += page
       page_no += 1
     end
-    assert mappings.length > 0
+    refute mappings.empty?
     cui = 0
     same_uri = 0
     loom = 0
     mappings.each do |map|
       assert_equal(map.classes[0].submission.ontology.acronym,
                    latest_sub.ontology.acronym)
-      if map.source == "CUI"
+      if map.source == 'CUI'
         cui += 1
-      elsif map.source == "SAME_URI"
+      elsif map.source == 'SAME_URI'
         same_uri += 1
-      elsif map.source == "LOOM"
+      elsif map.source == 'LOOM'
         loom += 1
       else
-        assert 1 == 0, "unknown source for this ontology #{map.source}"
+        assert 1.zero?, "unknown source for this ontology #{map.source}"
       end
-      assert validate_mapping(map), "mapping is not valid"
+      assert validate_mapping(map), 'mapping is not valid'
     end
     assert create_count_mapping > 2
 
@@ -156,11 +177,11 @@ class TestMapping < LinkedData::TestOntologyCommon
       total += v
     end
     assert(by_ont_counts.length == 2)
-    ["MAPPING_TEST2", "MAPPING_TEST4"].each do |x|
+    ['MAPPING_TEST2', 'MAPPING_TEST4'].each do |x|
       assert(by_ont_counts.include?(x))
     end
-    assert_equal(by_ont_counts["MAPPING_TEST2"], 10)
-    assert_equal(by_ont_counts["MAPPING_TEST4"], 8)
+    assert_equal(by_ont_counts['MAPPING_TEST2'], 10)
+    assert_equal(by_ont_counts['MAPPING_TEST4'], 8)
     assert_equal(total, 18)
     assert_equal(mappings.length, 18)
     assert_equal(same_uri, 10)
@@ -169,7 +190,7 @@ class TestMapping < LinkedData::TestOntologyCommon
     mappings.each do |map|
       class_mappings = LinkedData::Mappings.mappings_ontology(
         latest_sub, 1, 100, map.classes[0].id)
-      assert class_mappings.length > 0
+      assert class_mappings.length.positive?
       class_mappings.each do |cmap|
         assert validate_mapping(map)
       end
@@ -177,7 +198,7 @@ class TestMapping < LinkedData::TestOntologyCommon
   end
 
   def test_mappings_two_ontologies
-    assert create_count_mapping > 2, "Mapping count should exceed the value of 2"
+    assert create_count_mapping > 2, 'Mapping count should exceed the value of 2'
     # bro
     ont1 = LinkedData::Models::Ontology.where({ :acronym => ONT_ACR1 }).to_a[0]
     # fake ont
@@ -206,16 +227,16 @@ class TestMapping < LinkedData::TestOntologyCommon
                    latest_sub1.ontology.acronym)
       assert_equal(map.classes[1].submission.ontology.acronym,
                    latest_sub2.ontology.acronym)
-      if map.source == "CUI"
+      if map.source == 'CUI'
         cui += 1
-      elsif map.source == "SAME_URI"
+      elsif map.source == 'SAME_URI'
         same_uri += 1
-      elsif map.source == "LOOM"
+      elsif map.source == 'LOOM'
         loom += 1
       else
-        assert 1 == 0, "unknown source for this ontology #{map.source}"
+        assert 1.zero?, "unknown source for this ontology #{map.source}"
       end
-      assert validate_mapping(map), "mapping is not valid"
+      assert validate_mapping(map), 'mapping is not valid'
     end
     count = LinkedData::Mappings.mapping_ontologies_count(latest_sub1, latest_sub2, true)
 
@@ -243,20 +264,20 @@ class TestMapping < LinkedData::TestOntologyCommon
                                               name: "proc#{i}")
     end
 
-    ont_id = submissions_a.first.split("/")[0..-3].join("/")
+    ont_id = submissions_a.first.split('/')[0..-3].join('/')
     latest_sub = LinkedData::Models::Ontology.find(RDF::URI.new(ont_id)).first.latest_submission
     assert create_count_mapping > 2
     mappings = LinkedData::Mappings.mappings_ontology(latest_sub, 1, 1000)
     rest_mapping_count = 0
 
     mappings.each do |m|
-      if m.source == "REST"
+      if m.source == 'REST'
         rest_mapping_count += 1
         assert_equal m.classes.length, 2
         c1 = m.classes.select {
-          |c| c.submission.id.to_s["TEST1"] }.first
+          |c| c.submission.id.to_s['TEST1'] }.first
         c2 = m.classes.select {
-          |c| c.submission.id.to_s["TEST2"] }.first
+          |c| c.submission.id.to_s['TEST2'] }.first
         assert c1 != nil
         assert c2 != nil
         ia = mapping_term_a.index c1.id.to_s
@@ -271,9 +292,9 @@ class TestMapping < LinkedData::TestOntologyCommon
     assert rest_mapping_count > 1 || rest_mapping_count < 4
     # in a new submission we should have moved the rest mappings
     submission_parse(ONT_ACR1,
-                            "MappingOntTest1",
-                            "./test/data/ontology_files/BRO_v3.3.owl", 12,
-                            process_rdf: true, extract_metadata: false)
+                     'MappingOntTest1',
+                     './test/data/ontology_files/BRO_v3.3.owl', 12,
+                     process_rdf: true, extract_metadata: false)
 
     assert create_count_mapping > 2
 
@@ -281,7 +302,7 @@ class TestMapping < LinkedData::TestOntologyCommon
     mappings = LinkedData::Mappings.mappings_ontology(latest_sub1, 1, 1000)
     rest_mapping_count = 0
     mappings.each do |m|
-      rest_mapping_count += 1 if m.source == "REST"
+      rest_mapping_count += 1 if m.source == 'REST'
     end
     assert_equal 3, rest_mapping_count
   end
@@ -327,23 +348,23 @@ class TestMapping < LinkedData::TestOntologyCommon
   end
 
   def rest_mapping_data
-    mapping_term_a = ["http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Image_Algorithm",
-                      "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Image",
-                      "http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Integration_and_Interoperability_Tools"]
+    mapping_term_a = ['http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Image_Algorithm',
+                      'http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Image',
+                      'http://bioontology.org/ontologies/BiomedicalResourceOntology.owl#Integration_and_Interoperability_Tools']
     submissions_a = [
-      "http://data.bioontology.org/ontologies/MAPPING_TEST1/submissions/latest",
-      "http://data.bioontology.org/ontologies/MAPPING_TEST1/submissions/latest",
-      "http://data.bioontology.org/ontologies/MAPPING_TEST1/submissions/latest"]
-    mapping_term_b = ["http://purl.org/incf/ontology/Computational_Neurosciences/cno_alpha.owl#cno_0000202",
-                      "http://purl.org/incf/ontology/Computational_Neurosciences/cno_alpha.owl#cno_0000203",
-                      "http://purl.org/incf/ontology/Computational_Neurosciences/cno_alpha.owl#cno_0000205"]
+      'http://data.bioontology.org/ontologies/MAPPING_TEST1/submissions/latest',
+      'http://data.bioontology.org/ontologies/MAPPING_TEST1/submissions/latest',
+      'http://data.bioontology.org/ontologies/MAPPING_TEST1/submissions/latest']
+    mapping_term_b = ['http://purl.org/incf/ontology/Computational_Neurosciences/cno_alpha.owl#cno_0000202',
+                      'http://purl.org/incf/ontology/Computational_Neurosciences/cno_alpha.owl#cno_0000203',
+                      'http://purl.org/incf/ontology/Computational_Neurosciences/cno_alpha.owl#cno_0000205']
     submissions_b = [
-      "http://data.bioontology.org/ontologies/MAPPING_TEST2/submissions/latest",
-      "http://data.bioontology.org/ontologies/MAPPING_TEST2/submissions/latest",
-      "http://data.bioontology.org/ontologies/MAPPING_TEST2/submissions/latest"]
-    relations = ["http://www.w3.org/2004/02/skos/core#exactMatch",
-                 "http://www.w3.org/2004/02/skos/core#closeMatch",
-                 "http://www.w3.org/2004/02/skos/core#relatedMatch"]
+      'http://data.bioontology.org/ontologies/MAPPING_TEST2/submissions/latest',
+      'http://data.bioontology.org/ontologies/MAPPING_TEST2/submissions/latest',
+      'http://data.bioontology.org/ontologies/MAPPING_TEST2/submissions/latest']
+    relations = ['http://www.w3.org/2004/02/skos/core#exactMatch',
+                 'http://www.w3.org/2004/02/skos/core#closeMatch',
+                 'http://www.w3.org/2004/02/skos/core#relatedMatch']
 
     user = LinkedData::Models::User.where.include(:username).all[0]
     assert user != nil
@@ -362,8 +383,8 @@ class TestMapping < LinkedData::TestOntologyCommon
 
   def validate_mapping(map)
     prop = map.source.downcase.to_sym
-    prop = :prefLabel if map.source == "LOOM"
-    prop = nil if map.source == "SAME_URI"
+    prop = :prefLabel if map.source == 'LOOM'
+    prop = nil if map.source == 'SAME_URI'
 
     classes = []
     map.classes.each do |t|
@@ -376,16 +397,16 @@ class TestMapping < LinkedData::TestOntologyCommon
       cls = cls.first
       classes << cls unless cls.nil?
     end
-    if map.source == "SAME_URI"
+    if map.source == 'SAME_URI'
       return classes[0].id.to_s == classes[1].id.to_s
     end
-    if map.source == "LOOM"
+    if map.source == 'LOOM'
       ldOntSub = LinkedData::Models::OntologySubmission
       label0 = ldOntSub.loom_transform_literal(classes[0].prefLabel)
       label1 = ldOntSub.loom_transform_literal(classes[1].prefLabel)
       return label0 == label1
     end
-    if map.source == "CUI"
+    if map.source == 'CUI'
       return classes[0].cui == classes[1].cui
     end
     return false


### PR DESCRIPTION
### Context 
Follow up of https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/167, to fix https://github.com/ontoportal-lirmm/ontologies_api/issues/106, https://github.com/agroportal/project-management/issues/560

To be sure to clean and remove the mapping that no longer exists, handle the two following cases:

- An ontology no longer exists
- An ontology has a new version that no longer has mapping with the existent ontologies 

To be sure that we still have the same count as before, I did this sheet comparing the old and new ways of doing the counts https://docs.google.com/spreadsheets/d/1QWDQCIkEYPo8oSs2YA34t7OHx4xQDaHAWOQacpSpXj0/edit?usp=sharing 

### Changes
* Refactor mapping count to simplify the code (https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/172/commits/650598b9fca65a06bf40f8a05a16a58f2a32950a)
* Clean the mapping_counts method (https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/172/commits/32ef2b5d1db4ad1df09c6b19d999fc7d754ce42e)
* Don't use delete_zombie_mapping_count in total mapping count (https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/172/commits/ad0e10e78dacdf7e377cd9a5f307e5f47a249e8b)
* Extract some smaller functions in mappings counts (https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/172/commits/35dba6b1514ac9e3da939e5f3bf420dc57acab65)