### PR TITLE
Fix: serialize default category attributes to show ontologies

### DIFF
--- a/lib/ontologies_linked_data/models/category.rb
+++ b/lib/ontologies_linked_data/models/category.rb
@@ -9,6 +9,7 @@ module LinkedData
       attribute :parentCategory, enforce: [:category, :list]
       attribute :ontologies, inverse: { on: :ontology, attribute: :hasDomain }
 
+      serialize_default :acronym, :name, :description, :created, :parentCategory, :ontologies
       cache_timeout 86400
     end
   end


### PR DESCRIPTION
Issues discussed in: https://github.com/ontoportal-lirmm/ontologies_api/issues/94#issuecomment-2552993431

### Context
When we call `/categories?display=all` we don't see the ontologies related to the categories until we invoke it manually by using `display=ontologies`

Why: because in the Category model the attributes are not serialized by default including `:ontologies` 

#### Solution
Add `serialized_default` to all category attributes