### PR TITLE
Feature: Implement mod api models

### DIFF
--- a/lib/ontologies_linked_data/config/config.rb
+++ b/lib/ontologies_linked_data/config/config.rb
@@ -187,7 +187,7 @@ module LinkedData
       conf.add_namespace(:adms, RDF::Vocabulary.new("http://www.w3.org/ns/adms#"))
       conf.add_namespace(:voaf, RDF::Vocabulary.new("http://purl.org/vocommons/voaf#"))
       conf.add_namespace(:dcat, RDF::Vocabulary.new("http://www.w3.org/ns/dcat#"))
-      conf.add_namespace(:mod, RDF::Vocabulary.new("http://www.isibang.ac.in/ns/mod#"))
+      conf.add_namespace(:mod, RDF::Vocabulary.new("https://w3id.org/mod#"))
       conf.add_namespace(:prov, RDF::Vocabulary.new("http://www.w3.org/ns/prov#"))
       conf.add_namespace(:cc, RDF::Vocabulary.new("http://creativecommons.org/ns#"))
       conf.add_namespace(:schema, RDF::Vocabulary.new("http://schema.org/"))

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -133,7 +133,11 @@ module LinkedData
                     LinkedData::Hypermedia::Link.new("labels", lambda {|s| "artefacts/#{s.acronym}/labels"}, LinkedData::Models::SKOS::Label.uri_type)
 
             
-            serialize_default :acronym, :title, :accessRights, :creator, :URI, :versionIRI, :description, :language
+            serialize_default :acronym, :accessRights, :subject, :URI, :versionIRI, :creator, :identifier, :status, :language, 
+                              :license, :rightsHolder, :description, :landingPage, :keyword, :bibliographicCitation, :contactPoint,
+                              :contributor, :publisher, :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, 
+                              :competencyQuestion, :wasGeneratedBy, :hasFormat, :includedInDataCatalog, :semanticArtefactRelation
+
             serialize_never :ontology
 
             def self.artefact_id_generator(ss)

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -1,0 +1,220 @@
+require 'ontologies_linked_data/models/mod/semantic_artefact_distribution'
+require 'ontologies_linked_data/models/skos/scheme'
+require 'ontologies_linked_data/models/skos/collection'
+require 'ontologies_linked_data/models/skos/skosxl'
+
+
+module LinkedData
+    module Models
+
+        class SemanticArtefact < LinkedData::Models::Base
+
+            class << self
+                attr_accessor :attribute_mappings
+                def attribute_mapped(name, **options)
+                  mapped_to = options.delete(:mapped_to)
+                  attribute(name, **options)
+                  @attribute_mappings ||= {}
+                  @attribute_mappings[name] = mapped_to if mapped_to
+                end
+            end
+
+            model :artefact, namespace: :mod, :name_with => :acronym
+            
+            # # SemanticArtefact attrs that map with ontology
+            attribute_mapped :acronym, namespace: :mod, mapped_to: { model: :ontology, attribute: :acronym }
+            attribute_mapped :title, namespace: :dcterms, mapped_to: { model: :ontology, attribute: :name }
+            attribute_mapped :accessRights, namespace: :dcterms , mapped_to: { model: :ontology, attribute: :viewingRestriction }
+            attribute_mapped :hasEvaluation, namespace: :mod, mapped_to: { model: :ontology, attribute: :reviews }
+            attribute_mapped :group, namespace: :mod, mapped_to: { model: :ontology, attribute: :group }
+            attribute_mapped :subject, namespace: :dcterms, mapped_to: { model: :ontology, attribute: :hasDomain }
+            attribute_mapped :usedInProject, namespace: :mod, mapped_to: { model: :ontology, attribute: :projects }
+            attribute_mapped :isPartOf, namespace: :dcterms, mapped_to:{model: :ontology, attribute: :viewOf}
+            attribute_mapped :propertyPartition, namespace: :void, mapped_to:{model: :ontology, attribute: :properties}
+            attribute_mapped :hasVersion, namespace: :dcterms, mapped_to:{model: :ontology, attribute: :submissions}
+
+            # SemanticArtefact attrs that maps with submission
+            attribute_mapped :URI, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :URI}
+            attribute_mapped :versionIRI, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :versionIRI}
+            attribute_mapped :identifier, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :identifier}
+            attribute_mapped :creator, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :hasCreator }
+            attribute_mapped :versionInfo, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :version}
+            attribute_mapped :status, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :status}
+            attribute_mapped :deprecated, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :deprecated}
+            attribute_mapped :language, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :naturalLanguage}
+            attribute_mapped :type, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :isOfType}
+            attribute_mapped :license, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :hasLicense}
+            attribute_mapped :useGuidelines, namespace: :cc, mapped_to: {model: :ontology_submission, attribute: :useGuidelines}
+            attribute_mapped :morePermissions, namespace: :cc, mapped_to: {model: :ontology_submission, attribute: :morePermissions}
+            attribute_mapped :rightsHolder, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :copyrightHolder}
+            attribute_mapped :description, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :description}
+            attribute_mapped :homepage, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :homepage}
+            attribute_mapped :landingPage, namespace: :dcat, mapped_to: {model: :ontology_submission, attribute: :documentation}
+            attribute_mapped :comment, namespace: :rdfs, mapped_to: {model: :ontology_submission, attribute: :notes}
+            attribute_mapped :keyword, namespace: :dcat, mapped_to: {model: :ontology_submission, attribute: :keywords}
+            attribute_mapped :alternative, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :alternative}
+            attribute_mapped :hiddenLabel, namespace: :skos, mapped_to: {model: :ontology_submission, attribute: :hiddenLabel}
+            attribute_mapped :abstract, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :abstract}
+            attribute_mapped :bibliographicCitation, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :publication}
+            attribute_mapped :contactPoint, namespace: :dcat, mapped_to: {model: :ontology_submission, attribute: :contact}
+            attribute_mapped :contributor, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :hasContributor}
+            attribute_mapped :curatedBy, namespace: :pav, mapped_to: {model: :ontology_submission, attribute: :curatedBy}
+            attribute_mapped :translator, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :translator}
+            attribute_mapped :publisher, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :publisher}
+            attribute_mapped :fundedBy, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :fundedBy}
+            attribute_mapped :endorsedBy, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :endorsedBy}
+            attribute_mapped :comment, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :notes}
+            attribute_mapped :audience, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :audience}
+            attribute_mapped :repository, namespace: :doap, mapped_to: {model: :ontology_submission, attribute: :repository}
+            attribute_mapped :bugDatabase, namespace: :doap, mapped_to: {model: :ontology_submission, attribute: :bugDatabase}
+            attribute_mapped :mailingList, namespace: :doap, mapped_to: {model: :ontology_submission, attribute: :mailingList}
+            attribute_mapped :toDoList, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :toDoList}
+            attribute_mapped :award, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :award}
+            attribute_mapped :knownUsage, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :knownUsage}
+            attribute_mapped :designedForTask, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :designedForOntologyTask}
+            attribute_mapped :coverage, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :coverage}
+            attribute_mapped :example, namespace: :vann, mapped_to: {model: :ontology_submission, attribute: :example}
+            attribute_mapped :createdWith, namespace: :pav, mapped_to: {model: :ontology_submission, attribute: :usedOntologyEngineeringTool}
+            attribute_mapped :accrualMethod, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :accrualMethod}
+            attribute_mapped :accrualPeriodicity, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :accrualPeriodicity}
+            attribute_mapped :accrualPolicy, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :accrualPolicy}
+            attribute_mapped :competencyQuestion, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :competencyQuestion}
+            attribute_mapped :wasGeneratedBy, namespace: :prov, mapped_to: {model: :ontology_submission, attribute: :wasGeneratedBy}
+            attribute_mapped :wasInvalidatedBy, namespace: :prov, mapped_to: {model: :ontology_submission, attribute: :wasInvalidatedBy}
+            attribute_mapped :isFormatOf, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :isFormatOf}
+            attribute_mapped :hasFormat, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :hasFormat}
+            attribute_mapped :uriLookupEndpoint, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :uriLookupEndpoint}
+            attribute_mapped :openSearchDescription, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :openSearchDescription}
+            attribute_mapped :source, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :source}
+            attribute_mapped :includedInDataCatalog, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :includedInDataCatalog}
+            attribute_mapped :priorVersion, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :hasPriorVersion}
+            attribute_mapped :hasPart, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :hasPart}
+            attribute_mapped :relation, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :ontologyRelatedTo}
+            attribute_mapped :semanticArtefactRelation, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :ontologyRelatedTo}
+            attribute_mapped :specializes, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :explanationEvolution}
+            attribute_mapped :generalizes, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :generalizes}
+            attribute_mapped :usedBy, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :usedBy}
+            attribute_mapped :reliesOn, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :ontologyRelatedTo}
+            attribute_mapped :similar, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :similarTo}
+            attribute_mapped :comesFromTheSameDomain, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :comesFromTheSameDomain}
+            attribute_mapped :hasEquivalencesWith, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :isAlignedTo}
+            attribute_mapped :backwardCompatibleWith, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :isBackwardCompatibleWith}
+            attribute_mapped :incompatibleWith, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :isIncompatibleWith}
+            attribute_mapped :hasDisparateModellingWith, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :hasDisparateModelling}
+            attribute_mapped :hasDisjunctionsWith, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :hasDisjunctionsWith}
+            attribute_mapped :workTranslation, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :workTranslation}
+            attribute_mapped :translationOfWork, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :translationOfWork}
+            attribute_mapped :uriRegexPattern, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :uriRegexPattern}
+            attribute_mapped :preferredNamespaceUri, namespace: :vann, mapped_to: {model: :ontology_submission, attribute: :preferredNamespaceUri}
+            attribute_mapped :preferredNamespacePrefix, namespace: :vann, mapped_to: {model: :ontology_submission, attribute: :preferredNamespacePrefix}
+            attribute_mapped :exampleResource, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :exampleIdentifier}
+            attribute_mapped :primaryTopic, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :keyClasses}
+            attribute_mapped :rootResource, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :roots}
+            attribute_mapped :changes, namespace: :vann, mapped_to: {model: :ontology_submission, attribute: :diffFilePath}
+            attribute_mapped :associatedMedia, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :associatedMedia}
+            attribute_mapped :depiction, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :depiction}
+            attribute_mapped :logo, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :logo}
+            attribute_mapped :metrics, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :metrics}
+
+
+            attribute :ontology, type: :ontology
+
+            links_load :acronym
+            #LinkedData::Hypermedia::Link.new("distributions", lambda {|s| "artefacts/#{s.acronym}/distributions"}, LinkedData::Models::SemanticArtefactDistribution.uri_type)
+            link_to LinkedData::Hypermedia::Link.new("record", lambda {|s| "artefacts/#{s.acronym}/record"}),
+                    LinkedData::Hypermedia::Link.new("resources", lambda {|s| "artefacts/#{s.acronym}/resources"}),
+                    LinkedData::Hypermedia::Link.new("single_resource", lambda {|s| "artefacts/#{s.acronym}/resources/{:resourceID}"}),
+                    LinkedData::Hypermedia::Link.new("classes", lambda {|s| "artefacts/#{s.acronym}/classes"}, LinkedData::Models::Class.uri_type),
+                    LinkedData::Hypermedia::Link.new("concepts", lambda {|s| "artefacts/#{s.acronym}/concepts"}, LinkedData::Models::Class.uri_type),
+                    LinkedData::Hypermedia::Link.new("properties", lambda {|s| "artefacts/#{s.acronym}/properties"}, "#{Goo.namespaces[:metadata].to_s}Property"),
+                    LinkedData::Hypermedia::Link.new("individuals", lambda {|s| "artefacts/#{s.acronym}/classes/roots"}, LinkedData::Models::Class.uri_type),
+                    LinkedData::Hypermedia::Link.new("schemes", lambda {|s| "artefacts/#{s.acronym}/schemes"}, LinkedData::Models::SKOS::Scheme.uri_type),
+                    LinkedData::Hypermedia::Link.new("collection", lambda {|s| "artefacts/#{s.acronym}/collections"}, LinkedData::Models::SKOS::Collection.uri_type),
+                    LinkedData::Hypermedia::Link.new("labels", lambda {|s| "artefacts/#{s.acronym}/labels"}, LinkedData::Models::SKOS::Label.uri_type)
+
+            
+            serialize_default :acronym, :title, :accessRights, :creator, :URI, :versionIRI, :description, :language
+            serialize_never :ontology
+                    
+            def initialize
+                super
+            end
+
+            def self.find(artefact_id)
+                ont = Ontology.find(artefact_id).include(:acronym).first
+                return nil unless ont
+
+                new.tap do |sa|
+                    sa.ontology = ont
+                    sa.acronym = ont.acronym
+                end
+            end
+
+            # Method to fetch specific attributes and populate the SemanticArtefact instance
+            def bring(*attributes)
+                attributes = [attributes] unless attributes.is_a?(Array)
+                latest = @ontology.latest_submission(status: :ready)
+                attributes.each do |attr|
+                    mapping = self.class.attribute_mappings[attr]
+                    next if mapping.nil?
+
+                    model = mapping[:model]
+                    mapped_attr = mapping[:attribute]
+                    
+                    case model
+                    when :ontology
+                        @ontology.bring(*mapped_attr)
+                        self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
+                    when :ontology_submission
+                        if latest
+                            latest.bring(*mapped_attr)
+                            self.send("#{attr}=", latest.send(mapped_attr))
+                        end
+                    end
+                end
+            end
+
+            def self.all_artefacts(options = {})
+                onts = if options[:allow_views]
+                        Ontology.where.to_a
+                    else
+                        Ontology.where.filter(Goo::Filter.new(:viewOf).unbound).include(:acronym).to_a
+                    end
+        
+                onts.map do |o|
+                    new.tap do |sa|
+                        sa.ontology = o
+                        sa.acronym = o.acronym
+                        sa.bring(*options[:includes]) if options[:includes]
+                    end
+                end
+            end
+
+            def latest_distribution(status)
+                SemanticArtefactDistribution.new(@ontology.latest_submission(status))
+            end
+
+            def distribution(dist_id)
+                SemanticArtefactDistribution.new(@ontology.submission(dist_id))
+            end
+        
+            def all_distributions(options = {})
+                status = options[:status]
+                to_bring = options[:includes]
+                @ontology.bring(:submissions)
+        
+                @ontology.submissions.map do |submission|
+                    SemanticArtefactDistribution.new(submission).tap do |dist|
+                        dist.bring(*to_bring) if to_bring
+                    end
+                end
+            end
+    
+            def analytics
+                @ontology.analytics
+            end
+            
+        end
+    end
+end
+  

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -142,7 +142,7 @@ module LinkedData
 
             def self.artefact_id_generator(ss)
                 ss.ontology.bring(:acronym) if !ss.ontology.loaded_attributes.include?(:acronym)
-                raise ArgumentError, "Acronym is nil to generate id" if ss.ontology.acronym.nil?
+                raise ArgumentError, "Acronym is nil for ontology  #{ss.ontology.id} to generate id" if ss.ontology.acronym.nil?
                 return RDF::URI.new(
                   "#{(Goo.id_prefix)}artefacts/#{CGI.escape(ss.ontology.acronym.to_s)}"
                 )
@@ -191,7 +191,7 @@ module LinkedData
             end
 
             def self.all_artefacts(options = {})
-                onts = if options[:allow_views]
+                onts = if options[:also_include_views]
                         Ontology.where.to_a
                     else
                         Ontology.where.filter(Goo::Filter.new(:viewOf).unbound).include(:acronym).to_a

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
@@ -1,0 +1,106 @@
+module LinkedData
+    module Models
+
+        class SemanticArtefactDistribution < LinkedData::Models::Base
+            
+            class << self
+                attr_accessor :attribute_mappings
+                def attribute_mapped(name, **options)
+                  mapped_to = options.delete(:mapped_to)
+                  attribute(name, **options)
+                  @attribute_mappings ||= {}
+                  @attribute_mappings[name] = mapped_to if mapped_to
+                end
+            end
+
+            model :artefact_distribution, namespace: :mod, name_with: ->(s) { distribution_id_generator(s) }
+            
+            # SAD attrs that map with submission
+            attribute_mapped :distributionId, mapped_to: { model: :ontology_submission, attribute: :submissionId }
+            attribute_mapped :title, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :URI }
+            attribute_mapped :deprecated, namespace: :owl, mapped_to: { model: :ontology_submission, attribute: :deprecated }
+            attribute_mapped :hasRepresentationLanguage, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hasOntologyLanguage }
+            attribute_mapped :hasFormalityLevel, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hasFormalityLevel }
+            attribute_mapped :hasSyntax, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hasOntologySyntax }
+            attribute_mapped :useGuidelines, namespace: :cc, mapped_to: { model: :ontology_submission, attribute: :useGuidelines }
+            attribute_mapped :description, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :description }
+            attribute_mapped :created, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :released }
+            attribute_mapped :modified, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :modificationDate }
+            attribute_mapped :valid, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :valid }
+            attribute_mapped :curatedOn, namespace: :pav, mapped_to: { model: :ontology_submission, attribute: :curatedOn }
+            attribute_mapped :dateSubmitted, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :creationDate }
+            attribute_mapped :conformsToKnowledgeRepresentationParadigm, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :conformsToKnowledgeRepresentationParadigm }
+            attribute_mapped :usedEngineeringMethodology, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :usedOntologyEngineeringMethodology }
+            attribute_mapped :prefLabelProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :prefLabelProperty }
+            attribute_mapped :synonymProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :synonymProperty }
+            attribute_mapped :definitionProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :definitionProperty }
+            attribute_mapped :authorProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :authorProperty }
+            attribute_mapped :obsoleteProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :obsoleteProperty }
+            attribute_mapped :createdProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :createdProperty }
+            attribute_mapped :modifiedProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :modifiedProperty }
+            attribute_mapped :hierarchyProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hierarchyProperty }
+            attribute_mapped :accessURL, namespace: :dcat, mapped_to: { model: :ontology_submission, attribute: :pullLocation }
+            attribute_mapped :downloadURL, namespace: :dcat, mapped_to: { model: :ontology_submission, attribute: :dataDump }
+            attribute_mapped :endpoint, namespace: :sd, mapped_to: { model: :ontology_submission, attribute: :endpoint }
+            attribute_mapped :imports, namespace: :owl, mapped_to: { model: :ontology_submission, attribute: :useImports }
+            attribute_mapped :obsoleteParent, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :obsoleteParent }
+            attribute_mapped :metadataVoc, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :metadataVoc }
+            attribute_mapped :metrics, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :metrics }
+            attribute_mapped :numberOfClasses, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :class_count }
+
+            # SAD attrs that map with metrics
+            attribute_mapped :numberOfAxioms, namespace: :mod, mapped_to: { model: :metric, attribute: :numberOfAxioms }
+            attribute_mapped :maxDepth, namespace: :mod, mapped_to: { model: :metric, attribute: :maxDepth }
+            attribute_mapped :maxChildCount, namespace: :mod, mapped_to: { model: :metric, attribute: :maxChildCount }
+            attribute_mapped :averageChildCount, namespace: :mod, mapped_to: { model: :metric, attribute: :averageChildCount }
+            attribute_mapped :classesWithOneChild, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithOneChild }
+            attribute_mapped :classesWithMoreThan25Children, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithMoreThan25Children }
+            attribute_mapped :classesWithNoDefinition, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithNoDefinition }
+
+
+            # Attr special to SemanticArtefactDistribution
+            attribute :submission, type: :ontology_submission
+            
+            serialize_default :distributionId, :title, :deprecated, :hasRepresentationLanguage, :hasSyntax, :description, :created
+            serialize_never :submission
+
+
+            def self.distribution_id_generator(ss)
+                "generated_test_id_#{SecureRandom.uuid}"
+              end
+
+
+            def initialize(sub)
+                super()
+                @submission = sub
+                @submission.bring(*[:submissionId])
+                @type = "http://www.isibang.ac.in/ns/mod#SemanticartefactDistribution"
+                @distributionId = sub.submissionId
+            end
+
+            # Method to fetch specific attributes and populate the SemanticArtefact instance
+            def bring(*attributes)
+                attributes = [attributes] unless attributes.is_a?(Array)
+                attributes.each do |attr|
+                    mapping = self.class.attribute_mappings[attr]
+                    next if mapping.nil?
+
+                    model = mapping[:model]
+                    mapped_attr = mapping[:attribute]
+                    
+                    case model
+                    when :ontology_submission
+                        @submission.bring(*mapped_attr)
+                        self.send("#{attr}=", @submission.send(mapped_attr)) if @submission.respond_to?(mapped_attr)
+                    when :metrics
+                        next
+                        # TO-DO
+                    end
+                end
+            end
+
+        end
+
+    end
+end
+  

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
@@ -61,7 +61,10 @@ module LinkedData
             # Attr special to SemanticArtefactDistribution
             attribute :submission, type: :ontology_submission
             
-            serialize_default :distributionId, :title, :deprecated, :hasRepresentationLanguage, :hasSyntax, :description, :created
+            serialize_default :distributionId, :title, :hasRepresentationLanguage, :hasSyntax, :description, :created, :modified, 
+                              :conformsToKnowledgeRepresentationParadigm, :usedEngineeringMethodology, :prefLabelProperty, 
+                              :synonymProperty, :definitionProperty, :accessURL, :downloadURL
+
             serialize_never :submission
 
 

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -1,0 +1,96 @@
+require_relative "../../test_case"
+require_relative '../test_ontology_common'
+
+class TestArtefact < LinkedData::TestOntologyCommon
+
+    def test_create_artefact
+        sa = LinkedData::Models::SemanticArtefact.new
+        assert_equal LinkedData::Models::SemanticArtefact , sa.class
+        assert_equal LinkedData::Models::Base, sa.class.ancestors[1]
+    end
+
+    def test_find_artefact
+        create_test_ontology
+        sa = LinkedData::Models::SemanticArtefact.find('STY')
+        assert_equal LinkedData::Models::SemanticArtefact , sa.class
+        assert_equal "STY", sa.acronym
+        assert_equal "STY", sa.ontology.acronym
+    end
+
+
+    def test_goo_attrs_to_load
+        attrs = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
+        assert_equal  [:acronym, :title, :accessRights, :creator, :URI, :versionIRI, :description, :language], attrs
+    end
+
+    def test_bring_attrs
+        create_test_ontology
+        r = LinkedData::Models::SemanticArtefact.find('STY')
+        r.bring(*LinkedData::Models::SemanticArtefact.goo_attrs_to_load([:all]))
+        ont = r.ontology
+        latest_sub = r.ontology.latest_submission
+        latest_sub.bring(*LinkedData::Models::OntologySubmission.goo_attrs_to_load([:all]))
+
+        LinkedData::Models::SemanticArtefact.attribute_mappings.each do |artefact_key, mapping|
+            value_artefact_attr = r.send(artefact_key)
+            mapped_attr = mapping[:attribute]
+
+            case mapping[:model]
+            when :ontology
+                value_ontology_attr = ont.send(mapped_attr)
+                if value_ontology_attr.is_a?(Array)
+                    value_artefact_attr.each_with_index do |v, i|
+                        assert_equal v.id, value_ontology_attr[i].id
+                    end
+                else
+                    assert_equal value_artefact_attr, value_ontology_attr
+                end
+            when :ontology_submission
+                value_submission_attr = latest_sub.send(mapped_attr)
+
+                if value_submission_attr.is_a?(Array)
+                    value_artefact_attr.each_with_index do |v, i|
+                        assert_equal v.id, value_submission_attr[i].id
+                    end
+                else
+                    assert_equal value_artefact_attr, value_submission_attr
+                end
+            end
+        end
+
+        assert_equal r.analytics, ont.analytics
+    end
+
+    def test_latest_distribution
+        create_test_ontology
+        sa = LinkedData::Models::SemanticArtefact.find('STY')
+        assert_equal "STY", sa.acronym
+        latest_distribution = sa.latest_distribution(status: :any)
+
+        assert_equal LinkedData::Models::SemanticArtefactDistribution , latest_distribution.class
+        assert_equal 1, latest_distribution.distributionId
+        assert_equal 1, latest_distribution.submission.submissionId
+    end
+    
+    def test_distributions
+        create_test_ontology
+        r = LinkedData::Models::SemanticArtefact.find('STY')
+        options = {
+            status: "ANY",
+            includes: LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([])
+        }
+        all_distros = r.all_distributions(options)
+
+        assert_equal Array, all_distros.class
+        assert_equal 1, all_distros.length
+        assert_equal 1, all_distros.length
+        assert_equal LinkedData::Models::SemanticArtefactDistribution, all_distros[0].class
+        assert_equal Set[:distributionId, :title, :deprecated, :hasRepresentationLanguage, :hasSyntax, :description, :created], all_distros[0].loaded_attributes
+    end
+    
+    private
+    def create_test_ontology
+        acr = "STY"
+        init_test_ontology_msotest acr
+    end
+end

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -20,7 +20,10 @@ class TestArtefact < LinkedData::TestOntologyCommon
 
     def test_goo_attrs_to_load
         attrs = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
-        assert_equal  [:acronym, :title, :accessRights, :creator, :URI, :versionIRI, :description, :language], attrs
+        assert_equal [:acronym, :accessRights, :subject, :URI, :versionIRI, :creator, :identifier, :status, :language, 
+        :license, :rightsHolder, :description, :landingPage, :keyword, :bibliographicCitation, :contactPoint,
+        :contributor, :publisher, :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, 
+        :competencyQuestion, :wasGeneratedBy, :hasFormat, :includedInDataCatalog, :semanticArtefactRelation], attrs
     end
 
     def test_bring_attrs

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -88,7 +88,7 @@ class TestArtefact < LinkedData::TestOntologyCommon
         assert_equal 1, all_distros.length
         assert_equal 1, all_distros.length
         assert_equal LinkedData::Models::SemanticArtefactDistribution, all_distros[0].class
-        assert_equal Set[:distributionId, :title, :deprecated, :hasRepresentationLanguage, :hasSyntax, :description, :created], all_distros[0].loaded_attributes
+        assert_equal Set[:distributionId, :title, :hasRepresentationLanguage, :hasSyntax, :description, :created, :modified, :conformsToKnowledgeRepresentationParadigm, :usedEngineeringMethodology, :prefLabelProperty, :synonymProperty, :definitionProperty, :accessURL, :downloadURL], all_distros[0].loaded_attributes
     end
     
     private

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -6,7 +6,6 @@ class TestArtefact < LinkedData::TestOntologyCommon
     def test_create_artefact
         sa = LinkedData::Models::SemanticArtefact.new
         assert_equal LinkedData::Models::SemanticArtefact , sa.class
-        assert_equal LinkedData::Models::Base, sa.class.ancestors[1]
     end
 
     def test_find_artefact

--- a/test/models/mod/test_artefact_distribution.rb
+++ b/test/models/mod/test_artefact_distribution.rb
@@ -9,7 +9,6 @@ class TestArtefactDistribution < LinkedData::TestOntologyCommon
         sa.ontology.bring(*:submissions)
         sad = LinkedData::Models::SemanticArtefactDistribution.new(sa.ontology.submissions[0])
         assert_equal LinkedData::Models::SemanticArtefactDistribution , sad.class
-        assert_equal LinkedData::Models::Base, sad.class.ancestors[1]
         assert_equal "http://data.bioontology.org/artefacts/STY/distributions/1", sad.id.to_s
     end
 
@@ -25,7 +24,6 @@ class TestArtefactDistribution < LinkedData::TestOntologyCommon
         sa = LinkedData::Models::SemanticArtefact.find('STY')
         sa.ontology.bring(*:submissions)
         sad = LinkedData::Models::SemanticArtefactDistribution.new(sa.ontology.submissions[0])
-        assert_equal LinkedData::Models::Base, sad.class.ancestors[1]
         sad.bring(*LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([:all]))
     end
 

--- a/test/models/mod/test_artefact_distribution.rb
+++ b/test/models/mod/test_artefact_distribution.rb
@@ -1,0 +1,36 @@
+require_relative "../../test_case"
+require_relative '../test_ontology_common'
+
+class TestArtefactDistribution < LinkedData::TestOntologyCommon
+
+    def test_create_artefact_distribution
+        create_test_ontology
+        sa = LinkedData::Models::SemanticArtefact.find('STY')
+        sa.ontology.bring(*:submissions)
+        sad = LinkedData::Models::SemanticArtefactDistribution.new(sa.ontology.submissions[0])
+        assert_equal LinkedData::Models::SemanticArtefactDistribution , sad.class
+        assert_equal LinkedData::Models::Base, sad.class.ancestors[1]
+        assert_equal "http://data.bioontology.org/artefacts/STY/distributions/1", sad.id.to_s
+    end
+
+    def test_goo_attrs_to_load
+        attrs = LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([])
+        assert_equal [:distributionId, :title, :deprecated, :hasRepresentationLanguage, :hasSyntax, :description, :created], attrs
+    end
+
+    def test_bring_attrs
+        create_test_ontology
+        sa = LinkedData::Models::SemanticArtefact.find('STY')
+        sa.ontology.bring(*:submissions)
+        sad = LinkedData::Models::SemanticArtefactDistribution.new(sa.ontology.submissions[0])
+        assert_equal LinkedData::Models::Base, sad.class.ancestors[1]
+        sad.bring(*LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([:all]))
+    end
+
+    private
+    def create_test_ontology
+        acr = "STY"
+        init_test_ontology_msotest acr
+    end
+    
+end

--- a/test/models/mod/test_artefact_distribution.rb
+++ b/test/models/mod/test_artefact_distribution.rb
@@ -15,7 +15,9 @@ class TestArtefactDistribution < LinkedData::TestOntologyCommon
 
     def test_goo_attrs_to_load
         attrs = LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([])
-        assert_equal [:distributionId, :title, :deprecated, :hasRepresentationLanguage, :hasSyntax, :description, :created], attrs
+        assert_equal [:distributionId, :title, :hasRepresentationLanguage, :hasSyntax, :description, :created, :modified, 
+        :conformsToKnowledgeRepresentationParadigm, :usedEngineeringMethodology, :prefLabelProperty, 
+        :synonymProperty, :definitionProperty, :accessURL, :downloadURL], attrs
     end
 
     def test_bring_attrs


### PR DESCRIPTION
### Context
This pull request introduces the core models for the MOD-API, which are essential for managing semantic artefacts and their distributions.

### Implemented Models

1. **Semantic Artefact**  
   - Represents a semantic artefact with relevant metadata and properties.  

2. **Semantic Artefact Distribution**  
   - Represents a distribution of a semantic artefact, specifying its format and accessibility.  
 
 
3. Attributes that the models include are in this [GSheet](https://docs.google.com/spreadsheets/d/1nkb7s2WKZdba2g0gWCCOlY9stInbI4-GHfsEwQxdE9w/edit?gid=1259154776#gid=1259154776)

### Summary
These models serve as the foundation for the MOD-API and will be used to facilitate data retrieval and management of semantic artefacts and their distributions.

