### PR TITLE
Feature: Optimize mappings migration in ontology process 

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -286,7 +286,7 @@ module LinkedData
         name = filename.nil? ? File.basename(File.new(src).path) : File.basename(filename)
         # THIS LOGGER IS JUST FOR DEBUG - remove after NCBO-795 is closed
         logger = Logger.new(Dir.pwd + "/create_permissions.log")
-        if not Dir.exist? path_to_repo
+        unless Dir.exist? path_to_repo
           FileUtils.mkdir_p path_to_repo
           logger.debug("Dir created #{path_to_repo} | #{"%o" % File.stat(path_to_repo).mode} | umask: #{File.umask}") # NCBO-795
         end

--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_diff_generator.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_diff_generator.rb
@@ -72,7 +72,7 @@ module LinkedData
           @submission.save
           logger.info("Diff generated successfully for #{@submission.id}")
           logger.flush
-        rescue StoreError => e
+        rescue Exception => e
           logger.error("Diff process for #{@submission.id} failed - #{e.class}: #{e.message}")
           logger.flush
           raise e
@@ -82,5 +82,3 @@ module LinkedData
     end
   end
 end
-
-


### PR DESCRIPTION
### Context
When a new ontology submission is processed,we have a step that fetch all the RestMappings and migrate them from the old submission to the new.

The issue is that the query fetch all the RestMappings (which are a lot in StagePortal), and then filter them to find only the ones related the current ontology processed,

The optimization was to filter directly the SPARQL query to filter by ACRONYM and paginate it if the number of RestMapping exceed 1000 mappings

In StagePortal, we went from 2 minutes, to 3s, for BFO (as it does not have any REST mappings)
 
### Changes 
* Paginate and regex filter to migrate_rest_mappings (https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/179/commits/3299cdba14e3d480f4b4ab5a35236ec4bd765026)