### PR TITLE
Fix: Add `none` tag to non tagged labels by language

### DIFF
--- a/lib/ontologies_linked_data/services/submission_process/operations/submission_missing_labels.rb
+++ b/lib/ontologies_linked_data/services/submission_process/operations/submission_missing_labels.rb
@@ -194,6 +194,8 @@ module LinkedData
         if no_default_pref_label
           lang_rdfs_labels = c.label(include_languages: true)
 
+          lang_rdfs_labels = {none: lang_rdfs_labels} if lang_rdfs_labels.is_a?(Array) && !lang_rdfs_labels.blank?
+          
           # Set lang_rdfs_labels to { none: [] } if empty or no match for default label
           if Array(lang_rdfs_labels).empty? || (lang_rdfs_labels.keys & [portal_lang, :none, '@none']).empty?
             lang_rdfs_labels = { none: [] }


### PR DESCRIPTION
### Issue description:

```
    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CDNO_0000024">
        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CDNO_0000012"/>
        <rdfs:label rdf:datatype="http://www.w3.org/XML/1998/namespacestring">dietary fluorine</rdfs:label>
    </owl:Class>
```

This class in the ontology FOODON has a label that is not plain text but is typed with an rdf:datatype. As a result, it is not tagged with any language in Goo. This causes an issue where the label is returned as an array, breaking the code.

### Changes
- Updated the code to handle cases where class labels are returned as an array by converting the array of labels to a hash, assigning a language: none key to ensure proper handling.