### PR TITLE
Fix: Add default serialization attributes for agents

### DIFF
--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -20,7 +20,7 @@ module LinkedData
       embed_values affiliations: LinkedData::Models::Agent.goo_attrs_to_load + [identifiers: LinkedData::Models::AgentIdentifier.goo_attrs_to_load]
       serialize_methods :usages
       
-      serialize_default :name, :agentType, :acronym, :email, :homepage, :identifiers, :affiliations
+      serialize_default :name, :agentType, :acronym, :email, :homepage, :identifiers
 
       write_access :creator
       access_control_load :creator

--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -19,6 +19,8 @@ module LinkedData
       embed :identifiers, :affiliations
       embed_values affiliations: LinkedData::Models::Agent.goo_attrs_to_load + [identifiers: LinkedData::Models::AgentIdentifier.goo_attrs_to_load]
       serialize_methods :usages
+      
+      serialize_default :name, :agentType, :acronym, :email, :homepage, :identifiers, :affiliations
 
       write_access :creator
       access_control_load :creator

--- a/lib/ontologies_linked_data/models/agents/identifier.rb
+++ b/lib/ontologies_linked_data/models/agents/identifier.rb
@@ -13,6 +13,8 @@ module LinkedData
 
       embedded true
 
+      serialize_default  :notation, :schemaAgency
+    
       write_access :creator
       access_control_load :creator
 


### PR DESCRIPTION
Added default serialization attributes for `Agents` model to show the creator only if the `display` parameter is put to all.

- `get /agents`
```
[
  {
    "name": "TEST",
    "agentType": "person",
    "acronym": null,
    "email": null,
    "homepage": null,
    "identifiers": [
      {
        "notation": "0000-0002-3452-553X",
        "schemaAgency": "ORCID"
      }
    ],
    "affiliations": [],
    "@id": "http://0.0.0.0:9393/Agents/e8f7ea40-cae2-013d-4f89-0242ac130007",
    "@type": "http://xmlns.com/foaf/0.1/Agent",
    "@context": {
      "@vocab": "http://data.bioontology.org/metadata/",
      "agentType": "http://data.bioontology.org/metadata/agentType",
      "name": "http://xmlns.com/foaf/0.1/name",
      "homepage": "http://xmlns.com/foaf/0.1/homepage",
      "acronym": "http://www.w3.org/2004/02/skos/core#altLabel",
      "email": "http://xmlns.com/foaf/0.1/mbox",
      "identifiers": "http://www.w3.org/ns/adms#identifier",
      "affiliations": "http://www.w3.org/ns/org#memberOf",
      "@language": "en"
    }
  }
]
``` 

- `get /agents?display=all`
```
[
  {
    "id": "http://0.0.0.0:9393/Agents/e8f7ea40-cae2-013d-4f89-0242ac130007",
    "name": "TEST",
    "identifiers": [
      {
        "notation": "0000-0002-3452-553X",
        "schemaAgency": "ORCID"
      }
    ],
    "creator": "http://0.0.0.0:9393/users/admin",
    "agentType": "person",
    "homepage": null,
    "acronym": null,
    "email": null,
    "affiliations": [],
    "usages": {},
    "@id": "http://0.0.0.0:9393/Agents/e8f7ea40-cae2-013d-4f89-0242ac130007",
    "@type": "http://xmlns.com/foaf/0.1/Agent",
    "@context": {
      "@vocab": "http://data.bioontology.org/metadata/",
      "agentType": "http://data.bioontology.org/metadata/agentType",
      "name": "http://xmlns.com/foaf/0.1/name",
      "homepage": "http://xmlns.com/foaf/0.1/homepage",
      "acronym": "http://www.w3.org/2004/02/skos/core#altLabel",
      "email": "http://xmlns.com/foaf/0.1/mbox",
      "identifiers": "http://www.w3.org/ns/adms#identifier",
      "affiliations": "http://www.w3.org/ns/org#memberOf",
      "creator": {
        "@id": "http://data.bioontology.org/metadata/User",
        "@type": "@id"
      },
      "@language": "en"
    }
  }
]
```