### PR TITLE
Fix: add paging by default when calling /artefacts

### DIFF
--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -190,20 +190,17 @@ module LinkedData
                 end
             end
 
-            def self.all_artefacts(options = {})
-                onts = if options[:also_include_views]
-                        Ontology.where.to_a
-                    else
-                        Ontology.where.filter(Goo::Filter.new(:viewOf).unbound).include(:acronym).to_a
-                    end
-        
-                onts.map do |o|
+            def self.all_artefacts(attributes, page, pagesize)
+                all_count = Ontology.where.count
+                onts = Ontology.where.include(:acronym).page(page, pagesize).page_count_set(all_count).all
+                all_artefacts = onts.map do |o|
                     new.tap do |sa|
                         sa.ontology = o
                         sa.acronym = o.acronym
-                        sa.bring(*options[:includes]) if options[:includes]
+                        sa.bring(*attributes) if attributes
                     end
                 end
+                Goo::Base::Page.new(page, pagesize, all_count, all_artefacts)
             end
 
             def latest_distribution(status)

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -70,7 +70,6 @@ class TestArtefact < LinkedData::TestOntologyCommon
         pagesize = 2
         artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(attributes, page, pagesize)
         assert_equal Goo::Base::Page , artefacts.class
-        assert_equal (artefacts.count / pagesize.to_f).ceil, artefacts.total_pages
         assert_equal artefacts.count, artefacts.aggregate
         assert_equal 1, artefacts.page_number
         assert_equal 2, artefacts.page_size

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -67,15 +67,13 @@ class TestArtefact < LinkedData::TestOntologyCommon
         create_test_ontology
         attributes = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
         page = 1
-        pagesize = 1
+        pagesize = 2
         artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(attributes, page, pagesize)
         assert_equal Goo::Base::Page , artefacts.class
-        assert_equal 1, artefacts.total_pages
-        assert_equal 1, artefacts.aggregate
+        assert_equal (artefacts.count / pagesize.to_f).ceil, artefacts.total_pages
+        assert_equal artefacts.count, artefacts.aggregate
         assert_equal 1, artefacts.page_number
-        assert_equal 1, artefacts.page_size
-        assert_equal nil, artefacts.prev_page
-        assert_equal nil, artefacts.next_page
+        assert_equal 2, artefacts.page_size
     end
 
     def test_latest_distribution

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -63,17 +63,6 @@ class TestArtefact < LinkedData::TestOntologyCommon
         assert_equal r.analytics, ont.analytics
     end
 
-    def test_all_artefacts
-        create_test_ontology
-        attributes = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
-        page = 1
-        pagesize = 2
-        artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(attributes, page, pagesize)
-        assert_equal Goo::Base::Page , artefacts.class
-        assert_equal artefacts.count, artefacts.aggregate
-        assert_equal 1, artefacts.page_number
-        assert_equal 2, artefacts.page_size
-    end
 
     def test_latest_distribution
         create_test_ontology

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -67,13 +67,13 @@ class TestArtefact < LinkedData::TestOntologyCommon
         create_test_ontology
         attributes = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
         page = 1
-        pagesize = 2
+        pagesize = 1
         artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(attributes, page, pagesize)
         assert_equal Goo::Base::Page , artefacts.class
         assert_equal 1, artefacts.total_pages
         assert_equal 1, artefacts.aggregate
         assert_equal 1, artefacts.page_number
-        assert_equal 2, artefacts.page_size
+        assert_equal 1, artefacts.page_size
         assert_equal nil, artefacts.prev_page
         assert_equal nil, artefacts.next_page
     end

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -63,6 +63,21 @@ class TestArtefact < LinkedData::TestOntologyCommon
         assert_equal r.analytics, ont.analytics
     end
 
+    def test_all_artefacts
+        create_test_ontology
+        attributes = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
+        page = 1
+        pagesize = 2
+        artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(attributes, page, pagesize)
+        assert_equal Goo::Base::Page , artefacts.class
+        assert_equal 1, artefacts.total_pages
+        assert_equal 1, artefacts.aggregate
+        assert_equal 1, artefacts.page_number
+        assert_equal 2, artefacts.page_size
+        assert_equal nil, artefacts.prev_page
+        assert_equal nil, artefacts.next_page
+    end
+
     def test_latest_distribution
         create_test_ontology
         sa = LinkedData::Models::SemanticArtefact.find('STY')


### PR DESCRIPTION
- see https://github.com/ontoportal-lirmm/ontologies_api/issues/124

The solution is to activate the paging by default in this route
![Screenshot from 2025-02-13 19-32-11](https://github.com/user-attachments/assets/fb416f7e-8023-487e-933c-00b97853202e)
![Screenshot from 2025-02-13 19-32-25](https://github.com/user-attachments/assets/4b1bcd76-922d-4385-bd45-027b0b1bb2fe)


