### PR TITLE
Feature: add metrics in artefacts distributions

### DIFF
--- a/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_fetcher.rb
+++ b/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_fetcher.rb
@@ -1,49 +1,51 @@
 module LinkedData
     module Concerns
-        module AttributeFetcher
-            def bring(*attributes)
-                attributes = [attributes] unless attributes.is_a?(Array)
-            
-                attributes.each do |attr|
-                    
-                    mapping = self.class.attribute_mappings[attr]
-                    next if mapping.nil?
-            
-                    model = mapping[:model]
-                    mapped_attr = mapping[:attribute]
-            
-                    case model
-                    when :ontology
-                        fetch_from_ontology(attr, mapped_attr)
-                    when :ontology_submission
-                        fetch_from_submission(attr, mapped_attr)
-                    when :metric
-                        fetch_from_metrics(attr, mapped_attr)
+        module SemanticArtefact
+            module AttributeFetcher
+                def bring(*attributes)
+                    attributes = [attributes] unless attributes.is_a?(Array)
+                
+                    attributes.each do |attr|
+                        
+                        mapping = self.class.attribute_mappings[attr]
+                        next if mapping.nil?
+                
+                        model = mapping[:model]
+                        mapped_attr = mapping[:attribute]
+                
+                        case model
+                        when :ontology
+                            fetch_from_ontology(attr, mapped_attr)
+                        when :ontology_submission
+                            fetch_from_submission(attr, mapped_attr)
+                        when :metric
+                            fetch_from_metrics(attr, mapped_attr)
+                        end
                     end
                 end
-            end
-        
-            private
-        
-            def fetch_from_ontology(attr, mapped_attr)
-                @ontology.bring(*mapped_attr)
-                self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
-            end
-        
-            def fetch_from_submission(attr, mapped_attr)
-                latest = defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
-                return unless latest
-                latest.bring(*mapped_attr)
-                self.send("#{attr}=", latest.send(mapped_attr)) if latest.respond_to?(mapped_attr)
-            end
-        
-            def fetch_from_metrics(attr, mapped_attr)
-                latest = defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
-                return unless latest
-                latest.bring(metrics: [mapped_attr])
-                metrics = latest.metrics
-                metric_value = metrics&.respond_to?(mapped_attr) ? metrics.send(mapped_attr) || 0 : 0
-                self.send("#{attr}=", metric_value)
+            
+                private
+            
+                def fetch_from_ontology(attr, mapped_attr)
+                    @ontology.bring(*mapped_attr)
+                    self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
+                end
+            
+                def fetch_from_submission(attr, mapped_attr)
+                    latest = defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
+                    return unless latest
+                    latest.bring(*mapped_attr)
+                    self.send("#{attr}=", latest.send(mapped_attr)) if latest.respond_to?(mapped_attr)
+                end
+            
+                def fetch_from_metrics(attr, mapped_attr)
+                    latest = defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
+                    return unless latest
+                    latest.bring(metrics: [mapped_attr])
+                    metrics = latest.metrics
+                    metric_value = metrics&.respond_to?(mapped_attr) ? metrics.send(mapped_attr) || 0 : 0
+                    self.send("#{attr}=", metric_value)
+                end
             end
         end
     end

--- a/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_fetcher.rb
+++ b/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_fetcher.rb
@@ -1,0 +1,50 @@
+module LinkedData
+    module Concerns
+        module AttributeFetcher
+            def bring(*attributes)
+                attributes = [attributes] unless attributes.is_a?(Array)
+            
+                attributes.each do |attr|
+                    
+                    mapping = self.class.attribute_mappings[attr]
+                    next if mapping.nil?
+            
+                    model = mapping[:model]
+                    mapped_attr = mapping[:attribute]
+            
+                    case model
+                    when :ontology
+                        fetch_from_ontology(attr, mapped_attr)
+                    when :ontology_submission
+                        fetch_from_submission(attr, mapped_attr)
+                    when :metric
+                        fetch_from_metrics(attr, mapped_attr)
+                    end
+                end
+            end
+        
+            private
+        
+            def fetch_from_ontology(attr, mapped_attr)
+                @ontology.bring(*mapped_attr)
+                self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
+            end
+        
+            def fetch_from_submission(attr, mapped_attr)
+                latest = defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
+                return unless latest
+                latest.bring(*mapped_attr)
+                self.send("#{attr}=", latest.send(mapped_attr)) if latest.respond_to?(mapped_attr)
+            end
+        
+            def fetch_from_metrics(attr, mapped_attr)
+                latest = defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
+                return unless latest
+                latest.bring(metrics: [mapped_attr])
+                metrics = latest.metrics
+                metric_value = metrics&.respond_to?(mapped_attr) ? metrics.send(mapped_attr) || 0 : 0
+                self.send("#{attr}=", metric_value)
+            end
+        end
+    end
+end

--- a/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_mapping.rb
+++ b/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_mapping.rb
@@ -1,23 +1,25 @@
 module LinkedData
     module Concerns
-        module AttributeMapping
-            def self.included(base)
-                base.extend ClassMethods
-            end
-        
-            module ClassMethods
-                attr_accessor :attribute_mappings
-        
-                def attribute_mapped(name, **options)
-                    mapped_to = options.delete(:mapped_to)
-                    attribute(name, **options)
-                    @attribute_mappings ||= {}
-                    mapped_to[:attribute] ||= name if mapped_to
-                    @attribute_mappings[name] = mapped_to if mapped_to
+        module SemanticArtefact
+            module AttributeMapping
+                def self.included(base)
+                    base.extend ClassMethods
                 end
+            
+                module ClassMethods
+                    attr_accessor :attribute_mappings
+            
+                    def attribute_mapped(name, **options)
+                        mapped_to = options.delete(:mapped_to)
+                        attribute(name, **options)
+                        @attribute_mappings ||= {}
+                        mapped_to[:attribute] ||= name if mapped_to
+                        @attribute_mappings[name] = mapped_to if mapped_to
+                    end
 
-                def type_uri
-                    namespace[model_name].to_s
+                    def type_uri
+                        namespace[model_name].to_s
+                    end
                 end
             end
         end

--- a/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_mapping.rb
+++ b/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_mapping.rb
@@ -1,0 +1,25 @@
+module LinkedData
+    module Concerns
+        module AttributeMapping
+            def self.included(base)
+                base.extend ClassMethods
+            end
+        
+            module ClassMethods
+                attr_accessor :attribute_mappings
+        
+                def attribute_mapped(name, **options)
+                    mapped_to = options.delete(:mapped_to)
+                    attribute(name, **options)
+                    @attribute_mappings ||= {}
+                    mapped_to[:attribute] ||= name if mapped_to
+                    @attribute_mappings[name] = mapped_to if mapped_to
+                end
+
+                def type_uri
+                    namespace[model_name].to_s
+                end
+            end
+        end
+    end
+end

--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -44,7 +44,7 @@ module LinkedData
         # Get attributes, either provided, all, or default
         default_attrs = if !attributes.empty?
                           if attributes.first == :all
-                            (self.attributes + hypermedia_settings[:serialize_default]).uniq
+                            (self.attributes(:all) + hypermedia_settings[:serialize_default]).uniq
                           else
                             attributes - hypermedia_settings[:serialize_never]
                           end

--- a/lib/ontologies_linked_data/models/metric.rb
+++ b/lib/ontologies_linked_data/models/metric.rb
@@ -22,7 +22,7 @@ module LinkedData
 
       attribute :numberOfNotes, namespace: :mod, type: :integer
       attribute :numberOfUsingProjects, namespace: :mod, type: :integer
-      attribute :numberOfEnsorments, namespace: :mod, type: :integer
+      attribute :numberOfEndorsements, namespace: :mod, type: :integer
       attribute :numberOfEvaluations, namespace: :mod, type: :integer
       attribute :numberOfAgents, namespace: :mod, type: :integer
       attribute :numberOfObjectProperties, namespace: :mod, type: :integer

--- a/lib/ontologies_linked_data/models/metric.rb
+++ b/lib/ontologies_linked_data/models/metric.rb
@@ -20,6 +20,22 @@ module LinkedData
       attribute :numberOfAxioms, namespace: :omv, type: :integer
       attribute :entities, namespace: :void, type: :integer
 
+      attribute :numberOfNotes, namespace: :mod, type: :integer
+      attribute :numberOfUsingProjects, namespace: :mod, type: :integer
+      attribute :numberOfEnsorments, namespace: :mod, type: :integer
+      attribute :numberOfEvaluations, namespace: :mod, type: :integer
+      attribute :numberOfAgents, namespace: :mod, type: :integer
+      attribute :numberOfObjectProperties, namespace: :mod, type: :integer
+      attribute :numberOfDataProperties, namespace: :mod, type: :integer
+      attribute :numberOfLabels, namespace: :mod, type: :integer
+      attribute :numberOfDeprecated, namespace: :mod, type: :integer
+      attribute :classesWithNoLabel, namespace: :mod, type: :integer
+      attribute :classesWithNoFormalDefinition, namespace: :mod, type: :integer      
+      attribute :classesWithNoAuthorMetadata, namespace: :mod, type: :integer
+      attribute :classesWithNoDateMetadata, namespace: :mod, type: :integer
+      attribute :numberOfMappings, namespace: :mod, type: :integer
+      attribute :numberOfUsers, namespace: :mod, type: :integer
+
       cache_timeout 14400 # 4 hours
 
       # Hypermedia links

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -8,8 +8,8 @@ module LinkedData
     module Models
 
         class SemanticArtefact < LinkedData::Models::Base
-            include LinkedData::Concerns::AttributeMapping
-            include LinkedData::Concerns::AttributeFetcher
+            include LinkedData::Concerns::SemanticArtefact::AttributeMapping
+            include LinkedData::Concerns::SemanticArtefact::AttributeFetcher
 
             model :SemanticArtefact, namespace: :mod, name_with: ->(s) { artefact_id_generator(s) }
             

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -15,6 +15,7 @@ module LinkedData
                   mapped_to = options.delete(:mapped_to)
                   attribute(name, **options)
                   @attribute_mappings ||= {}
+                  mapped_to[:attribute] = name if mapped_to[:attribute].nil?
                   @attribute_mappings[name] = mapped_to if mapped_to
                 end
             end
@@ -22,106 +23,106 @@ module LinkedData
             model :SemanticArtefact, namespace: :mod, name_with: ->(s) { artefact_id_generator(s) }
             
             # # SemanticArtefact attrs that map with ontology
-            attribute_mapped :acronym, namespace: :mod, mapped_to: { model: :ontology, attribute: :acronym }
+            attribute_mapped :acronym, namespace: :mod, mapped_to: { model: :ontology }
             attribute_mapped :title, namespace: :dcterms, mapped_to: { model: :ontology, attribute: :name }
             attribute_mapped :accessRights, namespace: :dcterms , mapped_to: { model: :ontology, attribute: :viewingRestriction }
             attribute_mapped :hasEvaluation, namespace: :mod, mapped_to: { model: :ontology, attribute: :reviews }
-            attribute_mapped :group, namespace: :mod, mapped_to: { model: :ontology, attribute: :group }
+            attribute_mapped :group, namespace: :mod, mapped_to: { model: :ontology }
             attribute_mapped :subject, namespace: :dcterms, mapped_to: { model: :ontology, attribute: :hasDomain }
             attribute_mapped :usedInProject, namespace: :mod, mapped_to: { model: :ontology, attribute: :projects }
-            attribute_mapped :isPartOf, namespace: :dcterms, mapped_to:{model: :ontology, attribute: :viewOf}
-            attribute_mapped :propertyPartition, namespace: :void, mapped_to:{model: :ontology, attribute: :properties}
-            attribute_mapped :hasVersion, namespace: :dcterms, mapped_to:{model: :ontology, attribute: :submissions}
+            attribute_mapped :isPartOf, namespace: :dcterms, mapped_to:{ model: :ontology, attribute: :viewOf}
+            attribute_mapped :propertyPartition, namespace: :void, mapped_to:{ model: :ontology, attribute: :properties}
+            attribute_mapped :hasVersion, namespace: :dcterms, mapped_to:{ model: :ontology, attribute: :submissions}
 
             # SemanticArtefact attrs that maps with submission
-            attribute_mapped :URI, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :URI}
-            attribute_mapped :versionIRI, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :versionIRI}
-            attribute_mapped :identifier, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :identifier}
+            attribute_mapped :URI, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :versionIRI, namespace: :owl, mapped_to: { model: :ontology_submission }
+            attribute_mapped :identifier, namespace: :dcterms, mapped_to: { model: :ontology_submission }
             attribute_mapped :creator, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :hasCreator }
-            attribute_mapped :versionInfo, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :version}
-            attribute_mapped :status, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :status}
-            attribute_mapped :deprecated, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :deprecated}
-            attribute_mapped :language, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :naturalLanguage}
-            attribute_mapped :type, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :isOfType}
-            attribute_mapped :license, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :hasLicense}
-            attribute_mapped :useGuidelines, namespace: :cc, mapped_to: {model: :ontology_submission, attribute: :useGuidelines}
-            attribute_mapped :morePermissions, namespace: :cc, mapped_to: {model: :ontology_submission, attribute: :morePermissions}
-            attribute_mapped :rightsHolder, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :copyrightHolder}
-            attribute_mapped :description, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :description}
-            attribute_mapped :homepage, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :homepage}
-            attribute_mapped :landingPage, namespace: :dcat, mapped_to: {model: :ontology_submission, attribute: :documentation}
-            attribute_mapped :comment, namespace: :rdfs, mapped_to: {model: :ontology_submission, attribute: :notes}
-            attribute_mapped :keyword, namespace: :dcat, mapped_to: {model: :ontology_submission, attribute: :keywords}
-            attribute_mapped :alternative, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :alternative}
-            attribute_mapped :hiddenLabel, namespace: :skos, mapped_to: {model: :ontology_submission, attribute: :hiddenLabel}
-            attribute_mapped :abstract, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :abstract}
-            attribute_mapped :bibliographicCitation, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :publication}
-            attribute_mapped :contactPoint, namespace: :dcat, mapped_to: {model: :ontology_submission, attribute: :contact}
-            attribute_mapped :contributor, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :hasContributor}
-            attribute_mapped :curatedBy, namespace: :pav, mapped_to: {model: :ontology_submission, attribute: :curatedBy}
-            attribute_mapped :translator, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :translator}
-            attribute_mapped :publisher, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :publisher}
-            attribute_mapped :fundedBy, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :fundedBy}
-            attribute_mapped :endorsedBy, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :endorsedBy}
-            attribute_mapped :comment, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :notes}
-            attribute_mapped :audience, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :audience}
-            attribute_mapped :repository, namespace: :doap, mapped_to: {model: :ontology_submission, attribute: :repository}
-            attribute_mapped :bugDatabase, namespace: :doap, mapped_to: {model: :ontology_submission, attribute: :bugDatabase}
-            attribute_mapped :mailingList, namespace: :doap, mapped_to: {model: :ontology_submission, attribute: :mailingList}
-            attribute_mapped :toDoList, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :toDoList}
-            attribute_mapped :award, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :award}
-            attribute_mapped :knownUsage, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :knownUsage}
-            attribute_mapped :designedForTask, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :designedForOntologyTask}
-            attribute_mapped :coverage, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :coverage}
-            attribute_mapped :example, namespace: :vann, mapped_to: {model: :ontology_submission, attribute: :example}
-            attribute_mapped :createdWith, namespace: :pav, mapped_to: {model: :ontology_submission, attribute: :usedOntologyEngineeringTool}
-            attribute_mapped :accrualMethod, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :accrualMethod}
-            attribute_mapped :accrualPeriodicity, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :accrualPeriodicity}
-            attribute_mapped :accrualPolicy, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :accrualPolicy}
-            attribute_mapped :competencyQuestion, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :competencyQuestion}
-            attribute_mapped :wasGeneratedBy, namespace: :prov, mapped_to: {model: :ontology_submission, attribute: :wasGeneratedBy}
-            attribute_mapped :wasInvalidatedBy, namespace: :prov, mapped_to: {model: :ontology_submission, attribute: :wasInvalidatedBy}
-            attribute_mapped :isFormatOf, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :isFormatOf}
-            attribute_mapped :hasFormat, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :hasFormat}
-            attribute_mapped :uriLookupEndpoint, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :uriLookupEndpoint}
-            attribute_mapped :openSearchDescription, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :openSearchDescription}
-            attribute_mapped :source, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :source}
-            attribute_mapped :includedInDataCatalog, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :includedInDataCatalog}
-            attribute_mapped :priorVersion, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :hasPriorVersion}
-            attribute_mapped :hasPart, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :hasPart}
-            attribute_mapped :relation, namespace: :dcterms, mapped_to: {model: :ontology_submission, attribute: :ontologyRelatedTo}
-            attribute_mapped :semanticArtefactRelation, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :ontologyRelatedTo}
-            attribute_mapped :specializes, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :explanationEvolution}
-            attribute_mapped :generalizes, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :generalizes}
-            attribute_mapped :usedBy, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :usedBy}
-            attribute_mapped :reliesOn, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :ontologyRelatedTo}
-            attribute_mapped :similar, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :similarTo}
-            attribute_mapped :comesFromTheSameDomain, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :comesFromTheSameDomain}
-            attribute_mapped :hasEquivalencesWith, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :isAlignedTo}
-            attribute_mapped :backwardCompatibleWith, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :isBackwardCompatibleWith}
-            attribute_mapped :incompatibleWith, namespace: :owl, mapped_to: {model: :ontology_submission, attribute: :isIncompatibleWith}
-            attribute_mapped :hasDisparateModellingWith, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :hasDisparateModelling}
-            attribute_mapped :hasDisjunctionsWith, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :hasDisjunctionsWith}
-            attribute_mapped :workTranslation, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :workTranslation}
-            attribute_mapped :translationOfWork, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :translationOfWork}
-            attribute_mapped :uriRegexPattern, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :uriRegexPattern}
-            attribute_mapped :preferredNamespaceUri, namespace: :vann, mapped_to: {model: :ontology_submission, attribute: :preferredNamespaceUri}
-            attribute_mapped :preferredNamespacePrefix, namespace: :vann, mapped_to: {model: :ontology_submission, attribute: :preferredNamespacePrefix}
-            attribute_mapped :exampleResource, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :exampleIdentifier}
-            attribute_mapped :primaryTopic, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :keyClasses}
-            attribute_mapped :rootResource, namespace: :void, mapped_to: {model: :ontology_submission, attribute: :roots}
-            attribute_mapped :changes, namespace: :vann, mapped_to: {model: :ontology_submission, attribute: :diffFilePath}
-            attribute_mapped :associatedMedia, namespace: :schema, mapped_to: {model: :ontology_submission, attribute: :associatedMedia}
-            attribute_mapped :depiction, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :depiction}
-            attribute_mapped :logo, namespace: :foaf, mapped_to: {model: :ontology_submission, attribute: :logo}
-            attribute_mapped :metrics, namespace: :mod, mapped_to: {model: :ontology_submission, attribute: :metrics}
+            attribute_mapped :versionInfo, namespace: :owl, mapped_to: { model: :ontology_submission, attribute: :version}
+            attribute_mapped :status, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :deprecated, namespace: :owl, mapped_to: { model: :ontology_submission }
+            attribute_mapped :language, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :naturalLanguage}
+            attribute_mapped :type, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :isOfType}
+            attribute_mapped :license, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :hasLicense}
+            attribute_mapped :useGuidelines, namespace: :cc, mapped_to: { model: :ontology_submission }
+            attribute_mapped :morePermissions, namespace: :cc, mapped_to: { model: :ontology_submission }
+            attribute_mapped :rightsHolder, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :copyrightHolder}
+            attribute_mapped :description, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :homepage, namespace: :foaf, mapped_to: { model: :ontology_submission }
+            attribute_mapped :landingPage, namespace: :dcat, mapped_to: { model: :ontology_submission, attribute: :documentation}
+            attribute_mapped :comment, namespace: :rdfs, mapped_to: { model: :ontology_submission, attribute: :notes}
+            attribute_mapped :keyword, namespace: :dcat, mapped_to: { model: :ontology_submission, attribute: :keywords}
+            attribute_mapped :alternative, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :hiddenLabel, namespace: :skos, mapped_to: { model: :ontology_submission }
+            attribute_mapped :abstract, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :bibliographicCitation, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :publication}
+            attribute_mapped :contactPoint, namespace: :dcat, mapped_to: { model: :ontology_submission, attribute: :contact}
+            attribute_mapped :contributor, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :hasContributor}
+            attribute_mapped :curatedBy, namespace: :pav, mapped_to: { model: :ontology_submission }
+            attribute_mapped :translator, namespace: :schema, mapped_to: { model: :ontology_submission }
+            attribute_mapped :publisher, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :fundedBy, namespace: :foaf, mapped_to: { model: :ontology_submission }
+            attribute_mapped :endorsedBy, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :comment, namespace: :schema, mapped_to: { model: :ontology_submission, attribute: :notes}
+            attribute_mapped :audience, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :repository, namespace: :doap, mapped_to: { model: :ontology_submission }
+            attribute_mapped :bugDatabase, namespace: :doap, mapped_to: { model: :ontology_submission }
+            attribute_mapped :mailingList, namespace: :doap, mapped_to: { model: :ontology_submission }
+            attribute_mapped :toDoList, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :award, namespace: :schema, mapped_to: { model: :ontology_submission }
+            attribute_mapped :knownUsage, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :designedForTask, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :designedForOntologyTask}
+            attribute_mapped :coverage, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :example, namespace: :vann, mapped_to: { model: :ontology_submission }
+            attribute_mapped :createdWith, namespace: :pav, mapped_to: { model: :ontology_submission, attribute: :usedOntologyEngineeringTool}
+            attribute_mapped :accrualMethod, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :accrualPeriodicity, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :accrualPolicy, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :competencyQuestion, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :wasGeneratedBy, namespace: :prov, mapped_to: { model: :ontology_submission }
+            attribute_mapped :wasInvalidatedBy, namespace: :prov, mapped_to: { model: :ontology_submission }
+            attribute_mapped :isFormatOf, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :hasFormat, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :uriLookupEndpoint, namespace: :void, mapped_to: { model: :ontology_submission }
+            attribute_mapped :openSearchDescription, namespace: :void, mapped_to: { model: :ontology_submission }
+            attribute_mapped :source, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :includedInDataCatalog, namespace: :schema, mapped_to: { model: :ontology_submission }
+            attribute_mapped :priorVersion, namespace: :owl, mapped_to: { model: :ontology_submission, attribute: :hasPriorVersion}
+            attribute_mapped :hasPart, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :relation, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :ontologyRelatedTo}
+            attribute_mapped :semanticArtefactRelation, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :ontologyRelatedTo}
+            attribute_mapped :specializes, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :explanationEvolution}
+            attribute_mapped :generalizes, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :usedBy, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :reliesOn, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :ontologyRelatedTo}
+            attribute_mapped :similar, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :similarTo}
+            attribute_mapped :comesFromTheSameDomain, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :hasEquivalencesWith, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :isAlignedTo}
+            attribute_mapped :backwardCompatibleWith, namespace: :owl, mapped_to: { model: :ontology_submission, attribute: :isBackwardCompatibleWith}
+            attribute_mapped :incompatibleWith, namespace: :owl, mapped_to: { model: :ontology_submission, attribute: :isIncompatibleWith}
+            attribute_mapped :hasDisparateModellingWith, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hasDisparateModelling}
+            attribute_mapped :hasDisjunctionsWith, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :workTranslation, namespace: :schema, mapped_to: { model: :ontology_submission }
+            attribute_mapped :translationOfWork, namespace: :schema, mapped_to: { model: :ontology_submission }
+            attribute_mapped :uriRegexPattern, namespace: :void, mapped_to: { model: :ontology_submission }
+            attribute_mapped :preferredNamespaceUri, namespace: :vann, mapped_to: { model: :ontology_submission }
+            attribute_mapped :preferredNamespacePrefix, namespace: :vann, mapped_to: { model: :ontology_submission }
+            attribute_mapped :exampleResource, namespace: :void, mapped_to: { model: :ontology_submission, attribute: :exampleIdentifier}
+            attribute_mapped :primaryTopic, namespace: :foaf, mapped_to: { model: :ontology_submission, attribute: :keyClasses}
+            attribute_mapped :rootResource, namespace: :void, mapped_to: { model: :ontology_submission, attribute: :roots}
+            attribute_mapped :changes, namespace: :vann, mapped_to: { model: :ontology_submission, attribute: :diffFilePath}
+            attribute_mapped :associatedMedia, namespace: :schema, mapped_to: { model: :ontology_submission }
+            attribute_mapped :depiction, namespace: :foaf, mapped_to: { model: :ontology_submission }
+            attribute_mapped :logo, namespace: :foaf, mapped_to: { model: :ontology_submission }
+            attribute_mapped :metrics, namespace: :mod, mapped_to: { model: :ontology_submission }
 
-            attribute_mapped :numberOfNotes, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfNotes}
-            attribute_mapped :numberOfUsingProjects, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfUsingProjects}
-            attribute_mapped :numberOfEndorsements, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfEndorsements}
-            attribute_mapped :numberOfEvaluations, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfEvaluations}
-            attribute_mapped :numberOfUsers, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfUsers}
-            attribute_mapped :numberOfAgents, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfAgents}
+            attribute_mapped :numberOfNotes, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :numberOfUsingProjects, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :numberOfEndorsements, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :numberOfEvaluations, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :numberOfUsers, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :numberOfAgents, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
 
             attribute :ontology, type: :ontology
             
@@ -177,30 +178,31 @@ module LinkedData
                 attributes = [attributes] unless attributes.is_a?(Array)
                 latest = @ontology.latest_submission(status: :ready)
                 attributes.each do |attr|
-                    if self.class.handler?(attr)
-                        self.send(attr)
-                    else
-                        mapping = self.class.attribute_mappings[attr]
-                        next if mapping.nil?
+                    mapping = self.class.attribute_mappings[attr]
+                    next if mapping.nil?
     
-                        model = mapping[:model]
-                        mapped_attr = mapping[:attribute]
-                        
-                        case model
-                        when :ontology
-                            @ontology.bring(*mapped_attr)
-                            self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
-                        when :ontology_submission
-                            if latest
-                                latest.bring(*mapped_attr)
-                                self.send("#{attr}=", latest.send(mapped_attr))
-                            end
-                        when :metric
-                            latest.bring(*[:metrics => [mapped_attr]])
-                            if latest.metrics
-                                self.send("#{attr}=", latest.metrics.send(mapped_attr)) if latest.metrics.respond_to?(mapped_attr)
-                            end
+                    model = mapping[:model]
+                    mapped_attr = mapping[:attribute]
+                    
+                    case model
+                    when :ontology
+                        @ontology.bring(*mapped_attr)
+                        self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
+                    when :ontology_submission
+                        if latest
+                            latest.bring(*mapped_attr)
+                            self.send("#{attr}=", latest.send(mapped_attr)) if latest.respond_to?(mapped_attr)
                         end
+                    when :metric
+                        latest.bring(*[:metrics => [mapped_attr]])
+                        metrics = latest.metrics
+
+                        metric_value = if metrics && metrics.respond_to?(mapped_attr)
+                                            metrics.send(mapped_attr) || 0
+                                        else
+                                            0
+                                        end
+                        self.send("#{attr}=", metric_value)
                     end
                 end
             end

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
@@ -50,6 +50,7 @@ module LinkedData
             attribute_mapped :classesWithNoDefinition, namespace: :mod, mapped_to: { model: :metric }
             attribute_mapped :numberOfIndividuals, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric, attribute: :individuals}
             attribute_mapped :numberOfProperties, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric, attribute: :properties}
+            attribute_mapped :numberOfAgents, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
             attribute_mapped :numberOfObjectProperties, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric}
             attribute_mapped :numberOfDataProperties, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric}
             attribute_mapped :numberOfLabels, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
@@ -2,8 +2,8 @@ module LinkedData
     module Models
 
         class SemanticArtefactDistribution < LinkedData::Models::Base
-            include LinkedData::Concerns::AttributeMapping
-            include LinkedData::Concerns::AttributeFetcher
+            include LinkedData::Concerns::SemanticArtefact::AttributeMapping
+            include LinkedData::Concerns::SemanticArtefact::AttributeFetcher
 
             model :SemanticArtefactDistribution, namespace: :mod, name_with: ->(s) { distribution_id_generator(s) }
             

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
@@ -9,6 +9,7 @@ module LinkedData
                   mapped_to = options.delete(:mapped_to)
                   attribute(name, **options)
                   @attribute_mappings ||= {}
+                  mapped_to[:attribute] = name if mapped_to[:attribute].nil?
                   @attribute_mappings[name] = mapped_to if mapped_to
                 end
             end
@@ -18,55 +19,55 @@ module LinkedData
             # SAD attrs that map with submission
             attribute_mapped :distributionId, mapped_to: { model: :ontology_submission, attribute: :submissionId }
             attribute_mapped :title, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :URI }
-            attribute_mapped :deprecated, namespace: :owl, mapped_to: { model: :ontology_submission, attribute: :deprecated }
+            attribute_mapped :deprecated, namespace: :owl, mapped_to: { model: :ontology_submission }
             attribute_mapped :hasRepresentationLanguage, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hasOntologyLanguage }
-            attribute_mapped :hasFormalityLevel, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hasFormalityLevel }
+            attribute_mapped :hasFormalityLevel, namespace: :mod, mapped_to: { model: :ontology_submission }
             attribute_mapped :hasSyntax, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hasOntologySyntax }
-            attribute_mapped :useGuidelines, namespace: :cc, mapped_to: { model: :ontology_submission, attribute: :useGuidelines }
-            attribute_mapped :description, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :description }
+            attribute_mapped :useGuidelines, namespace: :cc, mapped_to: { model: :ontology_submission }
+            attribute_mapped :description, namespace: :dcterms, mapped_to: { model: :ontology_submission }
             attribute_mapped :created, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :released }
             attribute_mapped :modified, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :modificationDate }
-            attribute_mapped :valid, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :valid }
-            attribute_mapped :curatedOn, namespace: :pav, mapped_to: { model: :ontology_submission, attribute: :curatedOn }
+            attribute_mapped :valid, namespace: :dcterms, mapped_to: { model: :ontology_submission }
+            attribute_mapped :curatedOn, namespace: :pav, mapped_to: { model: :ontology_submission }
             attribute_mapped :dateSubmitted, namespace: :dcterms, mapped_to: { model: :ontology_submission, attribute: :creationDate }
-            attribute_mapped :conformsToKnowledgeRepresentationParadigm, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :conformsToKnowledgeRepresentationParadigm }
+            attribute_mapped :conformsToKnowledgeRepresentationParadigm, namespace: :mod, mapped_to: { model: :ontology_submission }
             attribute_mapped :usedEngineeringMethodology, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :usedOntologyEngineeringMethodology }
-            attribute_mapped :prefLabelProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :prefLabelProperty }
-            attribute_mapped :synonymProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :synonymProperty }
-            attribute_mapped :definitionProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :definitionProperty }
-            attribute_mapped :authorProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :authorProperty }
-            attribute_mapped :obsoleteProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :obsoleteProperty }
-            attribute_mapped :createdProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :createdProperty }
-            attribute_mapped :modifiedProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :modifiedProperty }
-            attribute_mapped :hierarchyProperty, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :hierarchyProperty }
+            attribute_mapped :prefLabelProperty, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :synonymProperty, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :definitionProperty, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :authorProperty, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :obsoleteProperty, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :createdProperty, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :modifiedProperty, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :hierarchyProperty, namespace: :mod, mapped_to: { model: :ontology_submission }
             attribute_mapped :accessURL, namespace: :dcat, mapped_to: { model: :ontology_submission, attribute: :pullLocation }
             attribute_mapped :downloadURL, namespace: :dcat, mapped_to: { model: :ontology_submission, attribute: :dataDump }
-            attribute_mapped :endpoint, namespace: :sd, mapped_to: { model: :ontology_submission, attribute: :endpoint }
+            attribute_mapped :endpoint, namespace: :sd, mapped_to: { model: :ontology_submission }
             attribute_mapped :imports, namespace: :owl, mapped_to: { model: :ontology_submission, attribute: :useImports }
-            attribute_mapped :obsoleteParent, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :obsoleteParent }
-            attribute_mapped :metadataVoc, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :metadataVoc }
-            attribute_mapped :metrics, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :metrics }
+            attribute_mapped :obsoleteParent, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :metadataVoc, namespace: :mod, mapped_to: { model: :ontology_submission }
+            attribute_mapped :metrics, namespace: :mod, mapped_to: { model: :ontology_submission }
 
             # SAD attrs that map with metrics
             attribute_mapped :numberOfClasses, namespace: :mod, mapped_to: { model: :metric, attribute: :classes }
-            attribute_mapped :numberOfAxioms, namespace: :mod, mapped_to: { model: :metric, attribute: :numberOfAxioms }
-            attribute_mapped :maxDepth, namespace: :mod, mapped_to: { model: :metric, attribute: :maxDepth }
-            attribute_mapped :maxChildCount, namespace: :mod, mapped_to: { model: :metric, attribute: :maxChildCount }
-            attribute_mapped :averageChildCount, namespace: :mod, mapped_to: { model: :metric, attribute: :averageChildCount }
-            attribute_mapped :classesWithOneChild, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithOneChild }
-            attribute_mapped :classesWithMoreThan25Children, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithMoreThan25Children }
-            attribute_mapped :classesWithNoDefinition, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithNoDefinition }
-            attribute_mapped :numberOfIndividuals, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :individuals}
-            attribute_mapped :numberOfProperties, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :properties}
-            attribute_mapped :numberOfObjectProperties, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfObjectProperties}
-            attribute_mapped :numberOfDataProperties, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfDataProperties}
-            attribute_mapped :numberOfLabels, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfLabels}
-            attribute_mapped :numberOfDeprecated, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfDeprecated}
-            attribute_mapped :classesWithNoFormalDefinition, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithNoFormalDefinition }
-            attribute_mapped :classesWithNoLabel, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :classesWithNoLabel}
-            attribute_mapped :classesWithNoAuthorMetadata, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :classesWithNoAuthorMetadata}
-            attribute_mapped :classesWithNoDateMetadata, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :classesWithNoDateMetadata}
-            attribute_mapped :numberOfMappings, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfMappings}
+            attribute_mapped :numberOfAxioms, namespace: :mod, mapped_to: { model: :metric }
+            attribute_mapped :maxDepth, namespace: :mod, mapped_to: { model: :metric }
+            attribute_mapped :maxChildCount, namespace: :mod, mapped_to: { model: :metric }
+            attribute_mapped :averageChildCount, namespace: :mod, mapped_to: { model: :metric }
+            attribute_mapped :classesWithOneChild, namespace: :mod, mapped_to: { model: :metric }
+            attribute_mapped :classesWithMoreThan25Children, namespace: :mod, mapped_to: { model: :metric }
+            attribute_mapped :classesWithNoDefinition, namespace: :mod, mapped_to: { model: :metric }
+            attribute_mapped :numberOfIndividuals, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric, attribute: :individuals}
+            attribute_mapped :numberOfProperties, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric, attribute: :properties}
+            attribute_mapped :numberOfObjectProperties, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric}
+            attribute_mapped :numberOfDataProperties, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric}
+            attribute_mapped :numberOfLabels, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :numberOfDeprecated, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :classesWithNoFormalDefinition, namespace: :mod, mapped_to: { model: :metric }
+            attribute_mapped :classesWithNoLabel, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :classesWithNoAuthorMetadata, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :classesWithNoDateMetadata, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
+            attribute_mapped :numberOfMappings, namespace: :mod, enforce: [:integer],  mapped_to: { model: :metric }
             
             # Attr special to SemanticArtefactDistribution
             attribute :submission, type: :ontology_submission
@@ -114,9 +115,13 @@ module LinkedData
                         self.send("#{attr}=", @submission.send(mapped_attr)) if @submission.respond_to?(mapped_attr)
                     when :metric
                         @submission.bring(*[:metrics => [mapped_attr]])
-                        if @submission.metrics
-                            self.send("#{attr}=", @submission.metrics.send(mapped_attr)) if @submission.metrics.respond_to?(mapped_attr)                          
-                        end
+                        metrics = @submission.metrics
+                        metric_value = if metrics && metrics.respond_to?(mapped_attr)
+                                            metrics.send(mapped_attr) || 0
+                                        else
+                                            0
+                                        end
+                        self.send("#{attr}=", metric_value)
                     end
                 end
             end

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
@@ -46,9 +46,9 @@ module LinkedData
             attribute_mapped :obsoleteParent, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :obsoleteParent }
             attribute_mapped :metadataVoc, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :metadataVoc }
             attribute_mapped :metrics, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :metrics }
-            attribute_mapped :numberOfClasses, namespace: :mod, mapped_to: { model: :ontology_submission, attribute: :class_count }
 
             # SAD attrs that map with metrics
+            attribute_mapped :numberOfClasses, namespace: :mod, mapped_to: { model: :metric, attribute: :classes }
             attribute_mapped :numberOfAxioms, namespace: :mod, mapped_to: { model: :metric, attribute: :numberOfAxioms }
             attribute_mapped :maxDepth, namespace: :mod, mapped_to: { model: :metric, attribute: :maxDepth }
             attribute_mapped :maxChildCount, namespace: :mod, mapped_to: { model: :metric, attribute: :maxChildCount }
@@ -56,8 +56,18 @@ module LinkedData
             attribute_mapped :classesWithOneChild, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithOneChild }
             attribute_mapped :classesWithMoreThan25Children, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithMoreThan25Children }
             attribute_mapped :classesWithNoDefinition, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithNoDefinition }
-
-
+            attribute_mapped :numberOfIndividuals, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :individuals}
+            attribute_mapped :numberOfProperties, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :properties}
+            attribute_mapped :numberOfObjectProperties, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfObjectProperties}
+            attribute_mapped :numberOfDataProperties, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfDataProperties}
+            attribute_mapped :numberOfLabels, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfLabels}
+            attribute_mapped :numberOfDeprecated, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfDeprecated}
+            attribute_mapped :classesWithNoFormalDefinition, namespace: :mod, mapped_to: { model: :metric, attribute: :classesWithNoFormalDefinition }
+            attribute_mapped :classesWithNoLabel, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :classesWithNoLabel}
+            attribute_mapped :classesWithNoAuthorMetadata, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :classesWithNoAuthorMetadata}
+            attribute_mapped :classesWithNoDateMetadata, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :classesWithNoDateMetadata}
+            attribute_mapped :numberOfMappings, namespace: :mod, enforce: [:integer],  mapped_to: {model: :metric, attribute: :numberOfMappings}
+            
             # Attr special to SemanticArtefactDistribution
             attribute :submission, type: :ontology_submission
             
@@ -102,9 +112,11 @@ module LinkedData
                     when :ontology_submission
                         @submission.bring(*mapped_attr)
                         self.send("#{attr}=", @submission.send(mapped_attr)) if @submission.respond_to?(mapped_attr)
-                    when :metrics
-                        next
-                        # TO-DO
+                    when :metric
+                        @submission.bring(*[:metrics => [mapped_attr]])
+                        if @submission.metrics
+                            self.send("#{attr}=", @submission.metrics.send(mapped_attr)) if @submission.metrics.respond_to?(mapped_attr)                          
+                        end
                     end
                 end
             end

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -16,7 +16,6 @@ class TestArtefact < LinkedData::TestOntologyCommon
         assert_equal "STY", sa.ontology.acronym
     end
 
-
     def test_goo_attrs_to_load
         attrs = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
         assert_equal [:acronym, :accessRights, :subject, :URI, :versionIRI, :creator, :identifier, :status, :language, 
@@ -42,10 +41,15 @@ class TestArtefact < LinkedData::TestOntologyCommon
                 value_ontology_attr = ont.send(mapped_attr)
                 if value_ontology_attr.is_a?(Array)
                     value_artefact_attr.each_with_index do |v, i|
-                        assert_equal v.id, value_ontology_attr[i].id
+                        expected_value = value_ontology_attr[i]
+                        if expected_value.respond_to?(:id) && v.respond_to?(:id)
+                            assert_equal expected_value.id, v.id
+                        else
+                            assert_equal expected_value, v
+                        end
                     end
                 else
-                    assert_equal value_artefact_attr, value_ontology_attr
+                    assert_equal value_ontology_attr, value_artefact_attr 
                 end
             when :ontology_submission
                 value_submission_attr = latest_sub.send(mapped_attr)
@@ -57,6 +61,14 @@ class TestArtefact < LinkedData::TestOntologyCommon
                 else
                     assert_equal value_artefact_attr, value_submission_attr
                 end
+            when :metric
+                metrics_obj = latest_sub.metrics
+                value_submission_metric_attr = if metrics_obj && metrics_obj.respond_to?(mapped_attr)
+                                                    metrics_obj.send(mapped_attr) || 0
+                                                else
+                                                    0
+                                                end
+                assert_equal value_artefact_attr, value_submission_metric_attr
             end
         end
 

--- a/test/models/mod/test_artefact_distribution.rb
+++ b/test/models/mod/test_artefact_distribution.rb
@@ -23,8 +23,41 @@ class TestArtefactDistribution < LinkedData::TestOntologyCommon
         create_test_ontology
         sa = LinkedData::Models::SemanticArtefact.find('STY')
         sa.ontology.bring(*:submissions)
-        sad = LinkedData::Models::SemanticArtefactDistribution.new(sa.ontology.submissions[0])
+        latest_sub = sa.ontology.submissions[0]
+        sad = LinkedData::Models::SemanticArtefactDistribution.new(latest_sub)
         sad.bring(*LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([:all]))
+        latest_sub.bring(*LinkedData::Models::OntologySubmission.goo_attrs_to_load([:all]))
+
+        LinkedData::Models::SemanticArtefactDistribution.attribute_mappings.each do |distribution_key, mapping|
+            value_distribution_attr = sad.send(distribution_key)
+            mapped_attr = mapping[:attribute]
+
+            case mapping[:model]
+            when :ontology_submission
+                value_submission_attr = latest_sub.send(mapped_attr)
+
+                if value_submission_attr.is_a?(Array)
+                    value_distribution_attr.each_with_index do |v, i|
+                        expected_value = value_submission_attr[i]
+                        if expected_value.respond_to?(:id) && v.respond_to?(:id)
+                            assert_equal expected_value.id, v.id
+                        else
+                            assert_equal expected_value, v
+                        end
+                    end
+                else
+                    assert_equal value_submission_attr, value_distribution_attr
+                end
+            when :metric
+                metrics_obj = latest_sub.metrics
+                value_submission_metric_attr = if metrics_obj && metrics_obj.respond_to?(mapped_attr)
+                                                    metrics_obj.send(mapped_attr) || 0
+                                                else
+                                                    0
+                                                end
+                assert_equal value_distribution_attr, value_submission_metric_attr
+            end
+        end
     end
 
     private


### PR DESCRIPTION
### Artefacts and Distribution metrics
- Defining the metrics to the metric model
- Adding the metric attribute to the models as a link to the metric attribute 
- Adding the other metrics attribute to artefact and distribution

### Screenshots
- metrics of artefacts
![Screenshot from 2025-02-14 11-37-43](https://github.com/user-attachments/assets/714ddd66-7f3d-4b5e-af2f-e5388ee6dbdf)

- metrics of distributions
![Screenshot from 2025-02-14 11-37-24](https://github.com/user-attachments/assets/8dd42397-ac95-4ac9-b494-db07358c6fff)
