### PR TITLE
Fix : GitHub OAuth Misconfiguration Allows Logging In as Another User

### DIFF
--- a/lib/ontologies_linked_data/models/users/oauth_authentication.rb
+++ b/lib/ontologies_linked_data/models/users/oauth_authentication.rb
@@ -70,7 +70,7 @@ module LinkedData
           end
 
           def user_by_email(email)
-            LinkedData::Models::User.where(email: email).first
+            LinkedData::Models::User.where(email: email).first unless email.nil?
           end
 
           def user_from_orcid_data(user_data)


### PR DESCRIPTION
## GitHub OAuth Misconfiguration
- If `email` is `nil`, the query `LinkedData::Models::User.where(email: email).first` would return the first user in the database, leading to unintended login as that user. 
- To prevent this, explicitly return `nil` if `email` is `nil`.

![Screenshot from 2025-02-20 15-44-55](https://github.com/user-attachments/assets/c05c0d73-5a1b-44c5-874c-4c16971eda1d)

- Even if we fix this the logic behind Github Oauth is still broken, because i can change my github email (it doesn't require verification) and put one of a portal admin.