### PR TITLE
Fix: remove all in goo attr to load

### DIFF
--- a/lib/ontologies_linked_data/models/base.rb
+++ b/lib/ontologies_linked_data/models/base.rb
@@ -44,7 +44,7 @@ module LinkedData
         # Get attributes, either provided, all, or default
         default_attrs = if !attributes.empty?
                           if attributes.first == :all
-                            (self.attributes(:all) + hypermedia_settings[:serialize_default]).uniq
+                            (self.attributes + hypermedia_settings[:serialize_default]).uniq
                           else
                             attributes - hypermedia_settings[:serialize_never]
                           end

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -133,7 +133,7 @@ module LinkedData
             # Access control
             read_restriction_based_on ->(artefct) { artefct.ontology }
 
-            serialize_default :acronym, :accessRights, :subject, :URI, :versionIRI, :creator, :identifier, :status, :language, 
+            serialize_default :acronym, :title, :accessRights, :subject, :URI, :versionIRI, :creator, :identifier, :status, :language, 
                               :license, :rightsHolder, :description, :landingPage, :keyword, :bibliographicCitation, :contactPoint,
                               :contributor, :publisher, :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, 
                               :competencyQuestion, :wasGeneratedBy, :hasFormat, :includedInDataCatalog, :semanticArtefactRelation

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
@@ -126,7 +126,9 @@ module LinkedData
                 define_method(handler) { calculate_attr_from_metrics(mapped_to) }
             end
               
-            serialize_default :acronym, :title, :color, :description, :logo, :fundedBy, :versionInfo, :homepage, :federated_portals
+            serialize_default :acronym, :title, :identifier, :status, :language, :type, :accessRights, :license, :rightsHolder, :description,
+                              :landingPage, :keyword, :bibliographicCitation, :created, :modified , :contactPoint, :creator, :contributor, 
+                              :publisher, :subject, :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, :wasGeneratedBy, :accessURL
 
             def ontologies_count
                 LinkedData::Models::Ontology.where(viewingRestriction: 'public').count

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
@@ -126,7 +126,7 @@ module LinkedData
                 define_method(handler) { calculate_attr_from_metrics(mapped_to) }
             end
               
-            serialize_default :acronym, :title, :color, :description, :logo, :fundedBy, :versionInfo, :homepage, :numberOfArtefacts, :federated_portals
+            serialize_default :acronym, :title, :color, :description, :logo, :fundedBy, :versionInfo, :homepage, :federated_portals
 
             def ontologies_count
                 LinkedData::Models::Ontology.where(viewingRestriction: 'public').count
@@ -184,6 +184,10 @@ module LinkedData
                 define_method("#{name}_url") do
                     RDF::URI(LinkedData.settings.id_url_prefix).join(name)
                 end
+            end
+
+            def self.load_computed_attributes
+                LinkedData::Models::SemanticArtefactCatalog.attributes(:handler)
             end
 
             def self.valid_hash_code(inst, attr)

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
@@ -186,10 +186,6 @@ module LinkedData
                 end
             end
 
-            def self.load_computed_attributes
-                LinkedData::Models::SemanticArtefactCatalog.attributes(:handler)
-            end
-
             def self.valid_hash_code(inst, attr)
                 inst.bring(attr) if inst.bring?(attr)
                 str = inst.send(attr)

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -18,7 +18,7 @@ class TestArtefact < LinkedData::TestOntologyCommon
 
     def test_goo_attrs_to_load
         attrs = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
-        assert_equal [:acronym, :accessRights, :subject, :URI, :versionIRI, :creator, :identifier, :status, :language, 
+        assert_equal [:acronym, :title, :accessRights, :subject, :URI, :versionIRI, :creator, :identifier, :status, :language, 
         :license, :rightsHolder, :description, :landingPage, :keyword, :bibliographicCitation, :contactPoint,
         :contributor, :publisher, :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, 
         :competencyQuestion, :wasGeneratedBy, :hasFormat, :includedInDataCatalog, :semanticArtefactRelation], attrs

--- a/test/models/mod/test_artefact_catalog.rb
+++ b/test/models/mod/test_artefact_catalog.rb
@@ -10,11 +10,10 @@ class TestArtefactCatalog < LinkedData::TestOntologyCommon
   end
 
   def test_goo_attrs_to_load
-      all_attrs = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([:all])
-      assert_equal LinkedData::Models::SemanticArtefactCatalog.attributes, all_attrs
-
       default_attrs = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([])
-      assert_equal [:acronym, :title, :color, :description, :logo, :fundedBy, :versionInfo, :homepage, :federated_portals], default_attrs
+      assert_equal [:acronym, :title, :identifier, :status, :language, :type, :accessRights, :license, :rightsHolder, 
+        :description, :landingPage, :keyword, :bibliographicCitation, :created, :modified, :contactPoint, :creator, 
+        :contributor, :publisher, :subject, :coverage, :createdWith, :accrualMethod, :accrualPeriodicity, :wasGeneratedBy, :accessURL], default_attrs
 
       specified_attrs = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([:acronym, :title, :keyword, :featureList])
       assert_equal [:acronym, :title, :keyword, :featureList], specified_attrs
@@ -32,6 +31,6 @@ class TestArtefactCatalog < LinkedData::TestOntologyCommon
     sac.save
     all_attrs_to_bring = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([:all])
     sac.bring(*all_attrs_to_bring)
-    assert_equal all_attrs_to_bring, sac.loaded_attributes.to_a
+    assert_equal all_attrs_to_bring.sort, (sac.loaded_attributes.to_a + [:type]).sort
   end
 end

--- a/test/models/mod/test_artefact_catalog.rb
+++ b/test/models/mod/test_artefact_catalog.rb
@@ -11,10 +11,10 @@ class TestArtefactCatalog < LinkedData::TestOntologyCommon
 
   def test_goo_attrs_to_load
       all_attrs = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([:all])
-      assert_equal LinkedData::Models::SemanticArtefactCatalog.attributes(:all), all_attrs
+      assert_equal LinkedData::Models::SemanticArtefactCatalog.attributes, all_attrs
 
       default_attrs = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([])
-      assert_equal [:acronym, :title, :color, :description, :logo, :fundedBy, :versionInfo, :homepage, :numberOfArtefacts, :federated_portals], default_attrs
+      assert_equal [:acronym, :title, :color, :description, :logo, :fundedBy, :versionInfo, :homepage, :federated_portals], default_attrs
 
       specified_attrs = LinkedData::Models::SemanticArtefactCatalog.goo_attrs_to_load([:acronym, :title, :keyword, :featureList])
       assert_equal [:acronym, :title, :keyword, :featureList], specified_attrs


### PR DESCRIPTION
i added this to load all attributes including with `:handler`
https://github.com/ontoportal-lirmm/ontologies_linked_data/blob/e3a3f5745c078624748ec612fe47da74a15dd4c2/lib/ontologies_linked_data/models/base.rb#L47

but apparently it affect some test in the ontologies_api 
https://github.com/ontoportal-lirmm/ontologies_api/actions/runs/13455600001/job/37598830121?pr=117#step:6:1160

so we remove for now