### PR TITLE
Fix: optimization for artefacts model

### DIFF
--- a/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_fetcher.rb
+++ b/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_fetcher.rb
@@ -10,7 +10,7 @@ module LinkedData
                         next unless mapping
                         model = mapping[:model]
                         mapped_attr = mapping[:attribute]
-                        hash[model][mapped_attr] = attr
+                        hash[model][attr] = mapped_attr
                     end
 
                     fetch_from_ontology(grouped_attributes[:ontology]) if grouped_attributes[:ontology].any?
@@ -22,8 +22,8 @@ module LinkedData
             
                 def fetch_from_ontology(attributes)
                     return if attributes.empty?
-                    @ontology.bring(*attributes.keys)
-                    attributes.each do |mapped_attr, attr|
+                    @ontology.bring(*attributes.values)
+                    attributes.each do |attr, mapped_attr|
                         self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
                     end
                 end
@@ -32,8 +32,8 @@ module LinkedData
                     return if attributes.empty?
                     @latest ||= defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
                     return unless @latest
-                    @latest.bring(*attributes.keys)
-                    attributes.each do |mapped_attr, attr|
+                    @latest.bring(*attributes.values)
+                    attributes.each do |attr, mapped_attr|
                         self.send("#{attr}=", @latest.send(mapped_attr)) if @latest.respond_to?(mapped_attr)
                     end
                 end
@@ -42,8 +42,8 @@ module LinkedData
                     return if attributes.empty?
                     @latest ||= defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
                     return unless @latest
-                    @latest.bring(metrics: [attributes.keys])
-                    attributes.each do |mapped_attr, attr|
+                    @latest.bring(metrics: [attributes.values])
+                    attributes.each do |attr, mapped_attr|
                         metric_value = @latest.metrics&.respond_to?(mapped_attr) ? @latest.metrics.send(mapped_attr) || 0 : 0
                         self.send("#{attr}=", metric_value)
                     end

--- a/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_fetcher.rb
+++ b/lib/ontologies_linked_data/concerns/semantic_artefact/attribute_fetcher.rb
@@ -3,48 +3,50 @@ module LinkedData
         module SemanticArtefact
             module AttributeFetcher
                 def bring(*attributes)
-                    attributes = [attributes] unless attributes.is_a?(Array)
-                
-                    attributes.each do |attr|
-                        
+                    attributes.flatten!
+
+                    grouped_attributes = attributes.each_with_object(Hash.new { |h, k| h[k] = {} }) do |attr, hash|
                         mapping = self.class.attribute_mappings[attr]
-                        next if mapping.nil?
-                
+                        next unless mapping
                         model = mapping[:model]
                         mapped_attr = mapping[:attribute]
-                
-                        case model
-                        when :ontology
-                            fetch_from_ontology(attr, mapped_attr)
-                        when :ontology_submission
-                            fetch_from_submission(attr, mapped_attr)
-                        when :metric
-                            fetch_from_metrics(attr, mapped_attr)
-                        end
+                        hash[model][mapped_attr] = attr
                     end
+
+                    fetch_from_ontology(grouped_attributes[:ontology]) if grouped_attributes[:ontology].any?
+                    fetch_from_submission(grouped_attributes[:ontology_submission]) if grouped_attributes[:ontology_submission].any?
+                    fetch_from_metrics(grouped_attributes[:metric]) if grouped_attributes[:metric].any?
                 end
             
                 private
             
-                def fetch_from_ontology(attr, mapped_attr)
-                    @ontology.bring(*mapped_attr)
-                    self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
+                def fetch_from_ontology(attributes)
+                    return if attributes.empty?
+                    @ontology.bring(*attributes.keys)
+                    attributes.each do |mapped_attr, attr|
+                        self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
+                    end
                 end
             
-                def fetch_from_submission(attr, mapped_attr)
-                    latest = defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
-                    return unless latest
-                    latest.bring(*mapped_attr)
-                    self.send("#{attr}=", latest.send(mapped_attr)) if latest.respond_to?(mapped_attr)
+                def fetch_from_submission(attributes)
+                    return if attributes.empty?
+                    @latest ||= defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
+                    return unless @latest
+                    @latest.bring(*attributes.keys)
+                    attributes.each do |mapped_attr, attr|
+                        self.send("#{attr}=", @latest.send(mapped_attr)) if @latest.respond_to?(mapped_attr)
+                    end
                 end
             
-                def fetch_from_metrics(attr, mapped_attr)
-                    latest = defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
-                    return unless latest
-                    latest.bring(metrics: [mapped_attr])
-                    metrics = latest.metrics
-                    metric_value = metrics&.respond_to?(mapped_attr) ? metrics.send(mapped_attr) || 0 : 0
-                    self.send("#{attr}=", metric_value)
+                def fetch_from_metrics(attributes)
+                    return if attributes.empty?
+                    @latest ||= defined?(@ontology) ? @ontology.latest_submission(status: :ready) : @submission
+                    return unless @latest
+                    @latest.bring(metrics: [attributes.keys])
+                    attributes.each do |mapped_attr, attr|
+                        metric_value = @latest.metrics&.respond_to?(mapped_attr) ? @latest.metrics.send(mapped_attr) || 0 : 0
+                        self.send("#{attr}=", metric_value)
+                    end
                 end
             end
         end

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -160,11 +160,10 @@ module LinkedData
 
             def self.all_artefacts(attributes, page, pagesize)
                 all_count = Ontology.where.count
-                onts = Ontology.where.include(:acronym, :viewingRestriction, :administeredBy, :acl).page(page, pagesize).page_count_set(all_count).all
+                onts = Ontology.where.include(:viewingRestriction, :administeredBy, :acl).page(page, pagesize).page_count_set(all_count).all
                 all_artefacts = onts.map do |o|
                     new.tap do |sa|
                         sa.ontology = o
-                        sa.acronym = o.acronym
                         sa.bring(*attributes) if attributes
                     end
                 end


### PR DESCRIPTION
### Context
- See issue: https://github.com/agroportal/project-management/issues/688

### Diagnosis
When we call `/artefacts?pagesize=1` and we check the logs of 4store (triple store) we see a lot of sparql queries are executed (in the image is just a portion of it)
![image](https://github.com/user-attachments/assets/afe78c12-e618-492e-b427-681c92e36e8d)

- Then number of queries that are executed for just one artefact  =  76 query (these are just for getting the attributes of the artefact)

- The reason for this is that 

1. the bring method in the attribute_fetcher.rb file, is bringing the attributes one by one
```ruby
attributes.each do |attr|
   ...
   when :ontology
      fetch_from_ontology(attr, mapped_attr)
   end
...
...
def fetch_from_ontology(attr, mapped_attr)
   @ontology.bring(*mapped_attr)
   self.send("#{attr}=", @ontology.send(mapped_attr)) if @ontology.respond_to?(mapped_attr)
end
```
2. recalculating the latest submission
3. doing queries even if we don't have attributes to bring

### Improvement
In this PR we change this behavior so that we bring the attribute in one call and one sparql query. The number of queries specific to the artefact after this reduced to 4
![image](https://github.com/user-attachments/assets/04fec3f7-6d91-435e-a2ca-f1bca6201766)

|  criteria  | Before  | After  |
|-----------|-----------|-----------|
| Number of queries for one artefact | 76   | 4   |

> there is also addional queries but they are fixed no matter the number of artefacts and it's just 4 queries (to get user and ontology)

- What's change 
   - Fix bring method so that we bring attributes in one call
   - Check if we will bring attributes from models
   - Refactor the code of attributes_fetcher.rb  