### PR TITLE
Feature: add hydra pagination to mod models

### DIFF
--- a/lib/ontologies_linked_data/models/mod/hydra_page.rb
+++ b/lib/ontologies_linked_data/models/mod/hydra_page.rb
@@ -1,0 +1,55 @@
+module LinkedData
+  module Models
+    class HydraPage < Goo::Base::Page
+
+      def convert_hydra_page(options, &block)
+        {
+          '@id': 'Collection',
+          '@type': 'hydra:Collection',
+          totalItems: self.aggregate,
+          itemsPerPage: self.size,
+          view: generate_hydra_page_view(options, self.page_number, self.total_pages),
+          collection: map { |item| item.to_flex_hash(options, &block) }
+        }
+      end
+      
+      def self.generate_hydra_context
+        {
+          'hydra': 'http://www.w3.org/ns/hydra/core#',
+          'Collection': 'hydra:Collection',
+          'collection': {'@id': 'hydra:member'},
+          'totalItems': 'hydra:totalItems',
+          'itemsPerPage': 'hydra:itemsPerPage',
+          'view': 'hydra:view',
+          'firstPage': 'hydra:first',
+          'lastPage': 'hydra:last',
+          'previousPage': 'hydra:previous',
+          'nextPage': 'hydra:next',
+        }
+      end
+      
+      private
+
+      def generate_hydra_page_view(options, page, page_count)
+        request = options[:request]
+        request_path = request ? "#{LinkedData.settings.rest_url_prefix.chomp("/")}#{request.path}" : nil
+        params = request ? request.params.dup : {}
+
+        build_url = ->(page_number) {
+          query = Rack::Utils.build_nested_query(params.merge("page" => page_number.to_s))
+          request_path ? "#{request_path}?#{query}" : "?#{query}"
+        }
+
+        {
+          "@id": build_url.call(page),
+          "@type": "hydra:PartialCollectionView",
+          firstPage: build_url.call(1),
+          previousPage: page > 1 ? build_url.call(page - 1) : nil,
+          nextPage: page < page_count ? build_url.call(page + 1) : nil,
+          lastPage: page_count != 0 ? build_url.call(page_count) : build_url.call(1)
+        }
+      end
+
+    end
+  end
+end

--- a/lib/ontologies_linked_data/models/mod/hydra_page.rb
+++ b/lib/ontologies_linked_data/models/mod/hydra_page.rb
@@ -9,7 +9,7 @@ module LinkedData
           totalItems: self.aggregate,
           itemsPerPage: self.size,
           view: generate_hydra_page_view(options, self.page_number, self.total_pages),
-          collection: map { |item| item.to_flex_hash(options, &block) }
+          member: map { |item| item.to_flex_hash(options, &block) }
         }
       end
       

--- a/lib/ontologies_linked_data/models/mod/hydra_page.rb
+++ b/lib/ontologies_linked_data/models/mod/hydra_page.rb
@@ -4,7 +4,7 @@ module LinkedData
 
       def convert_hydra_page(options, &block)
         {
-          '@id': 'Collection',
+          '@id': get_request_path(options),
           '@type': 'hydra:Collection',
           totalItems: self.aggregate,
           itemsPerPage: self.size,
@@ -31,9 +31,8 @@ module LinkedData
       private
 
       def generate_hydra_page_view(options, page, page_count)
-        request = options[:request]
-        request_path = request ? "#{LinkedData.settings.rest_url_prefix.chomp("/")}#{request.path}" : nil
-        params = request ? request.params.dup : {}
+        request_path = get_request_path(options)
+        params = options[:request] ? options[:request].params.dup : {}
 
         build_url = ->(page_number) {
           query = Rack::Utils.build_nested_query(params.merge("page" => page_number.to_s))
@@ -48,6 +47,11 @@ module LinkedData
           nextPage: page < page_count ? build_url.call(page + 1) : nil,
           lastPage: page_count != 0 ? build_url.call(page_count) : build_url.call(1)
         }
+      end
+      
+      def get_request_path(options)
+        request_path = options[:request] ? "#{LinkedData.settings.rest_url_prefix.chomp("/")}#{options[:request].path}" : nil
+        request_path
       end
 
     end

--- a/lib/ontologies_linked_data/models/mod/hydra_page.rb
+++ b/lib/ontologies_linked_data/models/mod/hydra_page.rb
@@ -17,7 +17,7 @@ module LinkedData
         {
           'hydra': 'http://www.w3.org/ns/hydra/core#',
           'Collection': 'hydra:Collection',
-          'collection': {'@id': 'hydra:member'},
+          'member': 'hydra:member',
           'totalItems': 'hydra:totalItems',
           'itemsPerPage': 'hydra:itemsPerPage',
           'view': 'hydra:view',

--- a/lib/ontologies_linked_data/models/mod/mod_base.rb
+++ b/lib/ontologies_linked_data/models/mod/mod_base.rb
@@ -1,0 +1,6 @@
+module LinkedData
+  module Models
+    class ModBase < LinkedData::Models::Base      
+    end
+  end
+end

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -121,7 +121,6 @@ module LinkedData
             link_to LinkedData::Hypermedia::Link.new("distributions", lambda {|s| "artefacts/#{s.acronym}/distributions"}, LinkedData::Models::SemanticArtefactDistribution.type_uri),
                     LinkedData::Hypermedia::Link.new("record", lambda {|s| "artefacts/#{s.acronym}/record"}),
                     LinkedData::Hypermedia::Link.new("resources", lambda {|s| "artefacts/#{s.acronym}/resources"}),
-                    LinkedData::Hypermedia::Link.new("single_resource", lambda {|s| "artefacts/#{s.acronym}/resources/{:resourceID}"}),
                     LinkedData::Hypermedia::Link.new("classes", lambda {|s| "artefacts/#{s.acronym}/classes"}, LinkedData::Models::Class.uri_type),
                     LinkedData::Hypermedia::Link.new("concepts", lambda {|s| "artefacts/#{s.acronym}/concepts"}, LinkedData::Models::Class.uri_type),
                     LinkedData::Hypermedia::Link.new("properties", lambda {|s| "artefacts/#{s.acronym}/properties"}, "#{Goo.namespaces[:metadata].to_s}Property"),

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -7,7 +7,7 @@ require 'ontologies_linked_data/models/skos/skosxl'
 module LinkedData
     module Models
 
-        class SemanticArtefact < LinkedData::Models::Base
+        class SemanticArtefact < LinkedData::Models::ModBase
             include LinkedData::Concerns::SemanticArtefact::AttributeMapping
             include LinkedData::Concerns::SemanticArtefact::AttributeFetcher
 

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact.rb
@@ -167,7 +167,7 @@ module LinkedData
                         sa.bring(*attributes) if attributes
                     end
                 end
-                Goo::Base::Page.new(page, pagesize, all_count, all_artefacts)
+                LinkedData::Models::HydraPage.new(page, pagesize, all_count, all_artefacts)
             end
 
             def latest_distribution(status)

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog.rb
@@ -16,7 +16,7 @@ require 'ontologies_linked_data/models/review'
 
 module LinkedData
     module Models
-        class SemanticArtefactCatalog < LinkedData::Models::Base
+        class SemanticArtefactCatalog < LinkedData::Models::ModBase
 
 
             model :SemanticArtefactCatalog, namespace: :mod, scheme: File.join(__dir__, '../../../../config/schemes/semantic_artefact_catalog.yml'),

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog_record.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog_record.rb
@@ -1,6 +1,6 @@
 module LinkedData
   module Models
-    class SemanticArtefactCatalogRecord < LinkedData::Models::Base
+    class SemanticArtefactCatalogRecord < LinkedData::Models::ModBase
       include LinkedData::Concerns::SemanticArtefact::AttributeMapping
       include LinkedData::Concerns::SemanticArtefact::AttributeFetcher
 

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog_record.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_catalog_record.rb
@@ -70,7 +70,7 @@ module LinkedData
             sacr.bring(*attributes) if attributes
           end
         end
-        Goo::Base::Page.new(page, pagesize, all_count, all_records)
+        LinkedData::Models::HydraPage.new(page, pagesize, all_count, all_records)
       end
       
       private

--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
@@ -1,7 +1,7 @@
 module LinkedData
     module Models
 
-        class SemanticArtefactDistribution < LinkedData::Models::Base
+        class SemanticArtefactDistribution < LinkedData::Models::ModBase
             include LinkedData::Concerns::SemanticArtefact::AttributeMapping
             include LinkedData::Concerns::SemanticArtefact::AttributeFetcher
 

--- a/lib/ontologies_linked_data/monkeypatches/object.rb
+++ b/lib/ontologies_linked_data/monkeypatches/object.rb
@@ -190,6 +190,8 @@ class Object
         new_hash[key] = value.to_flex_hash(options, &block)
       end
       return new_hash
+    elsif kind_of?(LinkedData::Models::HydraPage)
+      return self.convert_hydra_page(options, &block)
     elsif kind_of?(Goo::Base::Page)
       return convert_goo_page(options, &block)
     end

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -31,9 +31,8 @@ module LinkedData
           global_context["@context"].merge!(LinkedData::Models::HydraPage.generate_hydra_context)
         end
         result.merge!(global_context) unless global_context.empty?
-        result.merge!({ "@graph" => hash }) if hash.is_a?(Array)
         result.merge!(hash) if hash.is_a?(Hash)
-        # result.merge!(global_links) unless global_links.empty?
+        result.merge!(global_links) unless global_links.empty?
         MultiJson.dump(result)
       end
 
@@ -65,10 +64,9 @@ module LinkedData
         if global_links.nil?
           hash["links"] = links
           hash["links"].merge!(generate_links_context(hashed_obj)) if generate_context?(options)
-        # # we will enable this if we want links with the hydra schema
-        # elsif global_links.empty?
-        #   global_links["links"] = links
-        #   global_links["links"].merge!(generate_links_context(hashed_obj)) if generate_context?(options)
+        elsif global_links.empty?
+          global_links["links"] = links
+          global_links["links"].merge!(generate_links_context(hashed_obj)) if generate_context?(options)
         end
       end
 
@@ -94,15 +92,8 @@ module LinkedData
 
       def self.mod_object?(obj)
         return false if obj.nil?
-
         single_object = (obj.class == Array) && obj.any? ? obj.first : obj
-
-        # check the object class is one of the mod models
-        [
-          LinkedData::Models::HydraPage,
-          LinkedData::Models::SemanticArtefact,
-          LinkedData::Models::SemanticArtefactDistribution
-        ].any? { |klass| single_object.is_a?(klass) }
+        single_object.class.ancestors.include?(LinkedData::Models::HydraPage) || single_object.class.ancestors.include?(LinkedData::Models::ModBase)
       end
       
 

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -6,10 +6,10 @@ module LinkedData
       CONTEXTS = {}
 
       def self.serialize(obj, options = {})
-        # Handle mod object serialization apart to not break everything
+
         return serialize_mod_objects(obj, options) if mod_object?(obj)
 
-        # Handle the serialization for all other objects in the old way
+        # Handle the serialization for all other objects in the standard way
         hash = obj.to_flex_hash(options) do |hash, hashed_obj|
           process_common_serialization(hash, hashed_obj, options)
         end

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -6,49 +6,105 @@ module LinkedData
       CONTEXTS = {}
 
       def self.serialize(obj, options = {})
+        # Handle mod object serialization apart to not break everything
+        return serialize_mod_objects(obj, options) if mod_object?(obj)
 
-
+        # Handle the serialization for all other objects in the old way
         hash = obj.to_flex_hash(options) do |hash, hashed_obj|
-          current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class
-          result_lang = self.get_languages(get_object_submission(hashed_obj), options[:lang]) if result_lang.nil?
-
-          # Add the id to json-ld attribute
-          if current_cls.ancestors.include?(LinkedData::Hypermedia::Resource) && !current_cls.embedded? && hashed_obj.respond_to?(:id)
-            prefixed_id = LinkedData::Models::Base.replace_url_id_to_prefix(hashed_obj.id)
-            hash["@id"] = prefixed_id.to_s
-          end
-
-          # Add the type
-          hash["@type"] = type(current_cls, hashed_obj) if hash["@id"]
-
-          # Generate links
-          # NOTE: If this logic changes, also change in xml.rb
-          if generate_links?(options)
-            links = LinkedData::Hypermedia.generate_links(hashed_obj)
-            unless links.empty?
-              hash["links"] = links
-              hash["links"].merge!(generate_links_context(hashed_obj)) if generate_context?(options)
-            end
-          end
-
-          # Generate context
-          if current_cls.ancestors.include?(Goo::Base::Resource) && !current_cls.embedded?
-            if generate_context?(options)
-              context = generate_context(hashed_obj, hash.keys, options)
-              hash.merge!(context)
-            end
-          elsif (hashed_obj.instance_of?(LinkedData::Models::ExternalClass) || hashed_obj.instance_of?(LinkedData::Models::InterportalClass)) && !current_cls.embedded?
-            # Add context for ExternalClass
-            context_hash = { "@vocab" => Goo.vocabulary.to_s, "prefLabel" => "http://data.bioontology.org/metadata/skosprefLabel" }
-            context = { "@context" => context_hash }
-            hash.merge!(context)
-          end
-          hash['@context']['@language'] = result_lang if hash['@context']
+          process_common_serialization(hash, hashed_obj, options)
         end
         MultiJson.dump(hash)
       end
+      
+      def self.serialize_mod_objects(obj, options = {})
+        # using one context and links in mod objects
+        global_links, global_context = {}, {}
 
+        hash = obj.to_flex_hash(options) do |hash, hashed_obj|
+          process_common_serialization(hash, hashed_obj, options, global_links, global_context)
+        end
+
+        result = {}
+        # handle adding the context for HydraPage
+        if obj.is_a?(LinkedData::Models::HydraPage)
+          global_context["@context"] ||= {}
+          global_context["@context"].merge!(LinkedData::Models::HydraPage.generate_hydra_context)
+        end
+        result.merge!(global_context) unless global_context.empty?
+        result.merge!({ "@graph" => hash }) if hash.is_a?(Array)
+        result.merge!(hash) if hash.is_a?(Hash)
+        # result.merge!(global_links) unless global_links.empty?
+        MultiJson.dump(result)
+      end
+
+      
       private
+      
+      def self.process_common_serialization(hash, hashed_obj, options, global_links= nil, global_context= nil)
+        current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class
+        result_lang ||= get_languages(get_object_submission(hashed_obj), options[:lang])
+
+        add_id_and_type(hash, hashed_obj, current_cls)
+        add_links(hash, hashed_obj, options, global_links) if generate_links?(options)
+        add_context(hash, hashed_obj, options, current_cls, result_lang, global_context) if generate_context?(options)
+      end
+
+      def self.add_id_and_type(hash, hashed_obj, current_cls)
+        return unless current_cls.ancestors.include?(LinkedData::Hypermedia::Resource) && !current_cls.embedded? && hashed_obj.respond_to?(:id)
+
+        hash["@id"] = LinkedData::Models::Base.replace_url_id_to_prefix(hashed_obj.id).to_s
+        hash["@type"] = type(current_cls, hashed_obj) if hash["@id"]
+      end
+
+      def self.add_links(hash, hashed_obj, options, global_links)
+        return if global_links&.any?
+        
+        links = LinkedData::Hypermedia.generate_links(hashed_obj)
+        return if links.empty?
+
+        if global_links.nil?
+          hash["links"] = links
+          hash["links"].merge!(generate_links_context(hashed_obj)) if generate_context?(options)
+        # # we will enable this if we want links with the hydra schema
+        # elsif global_links.empty?
+        #   global_links["links"] = links
+        #   global_links["links"].merge!(generate_links_context(hashed_obj)) if generate_context?(options)
+        end
+      end
+
+      def self.add_context(hash, hashed_obj, options, current_cls, result_lang, global_context)
+        return if global_context&.any?
+        
+        context = generate_context(hashed_obj, hash.keys, options)
+
+        if global_context.nil?
+          if current_cls.ancestors.include?(Goo::Base::Resource) && !current_cls.embedded?
+              hash.merge!(context)
+          elsif (hashed_obj.instance_of?(LinkedData::Models::ExternalClass) || hashed_obj.instance_of?(LinkedData::Models::InterportalClass)) && !current_cls.embedded?
+            # Add context for ExternalClass
+            external_class_context = { "@context" => { "@vocab" => Goo.vocabulary.to_s, "prefLabel" => "http://data.bioontology.org/metadata/skosprefLabel" } }
+            hash.merge!(external_class_context)
+          end
+          hash['@context']['@language'] = result_lang if hash['@context']
+        elsif global_context.empty?
+          global_context.replace(context)
+          global_context["@context"]["@language"] = result_lang unless global_context.empty?
+        end
+      end
+
+      def self.mod_object?(obj)
+        return false if obj.nil?
+
+        single_object = (obj.class == Array) && obj.any? ? obj.first : obj
+
+        # check the object class is one of the mod models
+        [
+          LinkedData::Models::HydraPage,
+          LinkedData::Models::SemanticArtefact,
+          LinkedData::Models::SemanticArtefactDistribution
+        ].any? { |klass| single_object.is_a?(klass) }
+      end
+      
 
       def self.get_object_submission(obj)
         obj.class.respond_to?(:attributes) && obj.class.attributes.include?(:submission) ? obj.submission : nil

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -72,12 +72,11 @@ module LinkedData
 
       def self.add_context(hash, hashed_obj, options, current_cls, result_lang, global_context)
         return if global_context&.any?
-        
-        context = generate_context(hashed_obj, hash.keys, options)
 
         if global_context.nil?
           if current_cls.ancestors.include?(Goo::Base::Resource) && !current_cls.embedded?
-              hash.merge!(context)
+            context = generate_context(hashed_obj, hash.keys, options)
+            hash.merge!(context)
           elsif (hashed_obj.instance_of?(LinkedData::Models::ExternalClass) || hashed_obj.instance_of?(LinkedData::Models::InterportalClass)) && !current_cls.embedded?
             # Add context for ExternalClass
             external_class_context = { "@context" => { "@vocab" => Goo.vocabulary.to_s, "prefLabel" => "http://data.bioontology.org/metadata/skosprefLabel" } }
@@ -85,6 +84,7 @@ module LinkedData
           end
           hash['@context']['@language'] = result_lang if hash['@context']
         elsif global_context.empty?
+          context = generate_context(hashed_obj, hash.keys, options)
           global_context.replace(context)
           global_context["@context"]["@language"] = result_lang unless global_context.empty?
         end

--- a/lib/ontologies_linked_data/serializers/json.rb
+++ b/lib/ontologies_linked_data/serializers/json.rb
@@ -41,7 +41,7 @@ module LinkedData
       
       def self.process_common_serialization(hash, hashed_obj, options, global_links= nil, global_context= nil)
         current_cls = hashed_obj.respond_to?(:klass) ? hashed_obj.klass : hashed_obj.class
-        result_lang ||= get_languages(get_object_submission(hashed_obj), options[:lang])
+        result_lang = get_languages(get_object_submission(hashed_obj), options[:lang])
 
         add_id_and_type(hash, hashed_obj, current_cls)
         add_links(hash, hashed_obj, options, global_links) if generate_links?(options)

--- a/test/models/mod/test_artefact.rb
+++ b/test/models/mod/test_artefact.rb
@@ -3,13 +3,18 @@ require_relative '../test_ontology_common'
 
 class TestArtefact < LinkedData::TestOntologyCommon
 
+    def self.before_suite
+        backend_4s_delete
+        helper = LinkedData::TestOntologyCommon.new(self)
+        helper.init_test_ontology_msotest "STY"
+    end
+
     def test_create_artefact
         sa = LinkedData::Models::SemanticArtefact.new
         assert_equal LinkedData::Models::SemanticArtefact , sa.class
     end
 
     def test_find_artefact
-        create_test_ontology
         sa = LinkedData::Models::SemanticArtefact.find('STY')
         assert_equal LinkedData::Models::SemanticArtefact , sa.class
         assert_equal "STY", sa.acronym
@@ -25,7 +30,6 @@ class TestArtefact < LinkedData::TestOntologyCommon
     end
 
     def test_bring_attrs
-        create_test_ontology
         r = LinkedData::Models::SemanticArtefact.find('STY')
         r.bring(*LinkedData::Models::SemanticArtefact.goo_attrs_to_load([:all]))
         ont = r.ontology
@@ -77,7 +81,6 @@ class TestArtefact < LinkedData::TestOntologyCommon
 
 
     def test_latest_distribution
-        create_test_ontology
         sa = LinkedData::Models::SemanticArtefact.find('STY')
         assert_equal "STY", sa.acronym
         latest_distribution = sa.latest_distribution(status: :any)
@@ -87,25 +90,26 @@ class TestArtefact < LinkedData::TestOntologyCommon
         assert_equal 1, latest_distribution.submission.submissionId
     end
     
-    def test_distributions
-        create_test_ontology
-        r = LinkedData::Models::SemanticArtefact.find('STY')
-        options = {
-            status: "ANY",
-            includes: LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([])
-        }
-        all_distros = r.all_distributions(options)
+    def test_all_artefacts
+        attributes = LinkedData::Models::SemanticArtefact.goo_attrs_to_load([])
+        page = 1
+        pagesize = 1
+        all_artefacts = LinkedData::Models::SemanticArtefact.all_artefacts(attributes, page, pagesize)
+        assert_equal LinkedData::Models::HydraPage, all_artefacts.class
+        assert_equal 1, all_artefacts.length
+        assert_equal LinkedData::Models::SemanticArtefact, all_artefacts[0].class
+    end
 
-        assert_equal Array, all_distros.class
-        assert_equal 1, all_distros.length
+    def test_distributions
+        r = LinkedData::Models::SemanticArtefact.find('STY')
+        attributes =  LinkedData::Models::SemanticArtefactDistribution.goo_attrs_to_load([])
+        page = 1
+        pagesize = 1
+        all_distros = r.all_distributions(attributes, page, pagesize)
+        assert_equal LinkedData::Models::HydraPage, all_distros.class
         assert_equal 1, all_distros.length
         assert_equal LinkedData::Models::SemanticArtefactDistribution, all_distros[0].class
         assert_equal Set[:distributionId, :title, :hasRepresentationLanguage, :hasSyntax, :description, :created, :modified, :conformsToKnowledgeRepresentationParadigm, :usedEngineeringMethodology, :prefLabelProperty, :synonymProperty, :definitionProperty, :accessURL, :downloadURL], all_distros[0].loaded_attributes
     end
-    
-    private
-    def create_test_ontology
-        acr = "STY"
-        init_test_ontology_msotest acr
-    end
+
 end


### PR DESCRIPTION
### Context
- Fix for:
  - https://github.com/agroportal/project-management/issues/707
  - https://github.com/agroportal/project-management/issues/691
 
### Implementation
- In this pull request we are adding the hydra vocab to use it in our MOD-API paging results.
- This PR aimed to change the way we serialize our responses ensuring that we don't break the old serialization for all the routes so by that this hydra pagination + remove `@context` duplication will be applied only on the MOD-API routes.

### Screeshots
- page with elements
<img src="https://github.com/user-attachments/assets/c6ccd08a-f780-4c10-b623-5f1a80fbc896" width="400">

- empty page
<img src="https://github.com/user-attachments/assets/b3bec818-547b-4b9d-a0a4-2157cd6f08d0" width="400">






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enriched pagination with comprehensive navigational links and detailed pagination context.
  - Enhanced data output by standardizing response formatting with clear contextual and linked information.

- **Refactor**
  - Updated core data models to inherit from a new foundational base class, improving consistency across artefact handling.
  - Improved serialization logic for mod objects, enabling shared context and links aggregation for clearer data representation.
  - Refined data retrieval methods to support explicit pagination and attribute selection, enhancing performance and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->