### PR TITLE
Hotfix: handle non existing uploadFilePath in distribution bytesize

### DIFF
--- a/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
+++ b/lib/ontologies_linked_data/models/mod/semantic_artefact_distribution.rb
@@ -95,8 +95,8 @@ module LinkedData
             
             def calculate_byte_size
                 @submission.bring(:uploadFilePath) if @submission.bring?(:uploadFilePath)
-                updload_file_path = @submission.uploadFilePath
-                File.exist?(updload_file_path) ? File.size(updload_file_path) : 0
+                upload_file_path = @submission.uploadFilePath
+                File.exist?(upload_file_path.to_s) ? File.size(upload_file_path.to_s) : 0
             end
 
 


### PR DESCRIPTION
handle uploadFilePath when calculating bytesize for distribution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in file handling to prevent potential errors when calculating file sizes, improving reliability when viewing or managing file-related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->