### PR TITLE
FIx: Prevent recursive serialization of methods in embedded resources

### DIFF
--- a/lib/ontologies_linked_data/monkeypatches/object.rb
+++ b/lib/ontologies_linked_data/monkeypatches/object.rb
@@ -33,12 +33,13 @@ class Object
       only = Set.new(options[:include_for_class] || [])
     end
 
-    if all # Get everything
+    if all && !options[:nested] # Get everything if not an embedded object
       methods = self.class.hypermedia_settings[:serialize_methods] if self.is_a?(LinkedData::Hypermedia::Resource)
     end
 
-    # Check to see if we're nested, if so remove necessary properties
+    # Check to see if we're nested, if so remove necessary properties and serialize methods
     only = only - do_not_serialize_nested(options)
+    only -= self.class.hypermedia_settings[:serialize_methods] if options[:nested]
 
     # Determine whether to use defaults from the DSL or all attributes
     hash = populate_attributes(hash, all, only, options)


### PR DESCRIPTION
Fixed a bug where calling objects with serialized methods would also apply those methods to their embedded objects. This caused unintended recursion, significantly increasing the response time and potentially resulting in infinite loops for circular references.
Now, `serialize_methods` are excluded when serializing nested resources. This ensures embedded objects are serialized minimally without invoking unnecessary method calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serialization behavior to ensure nested objects only include allowed attributes, excluding serialization methods, for more accurate and secure data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->