### PR TITLE
Fix: limit agents embedded affiliations attributes

### DIFF
--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -17,7 +17,7 @@ module LinkedData
       attribute :affiliations, enforce: %i[Agent list is_organization], namespace: :org, property: :memberOf
       attribute :creator, type: :user, enforce: [:existence]
       embed :identifiers, :affiliations
-      embed_values affiliations: LinkedData::Models::Agent.goo_attrs_to_load + [identifiers: LinkedData::Models::AgentIdentifier.goo_attrs_to_load]
+      embed_values affiliations: [:name, :agentType, :homepage, :acronym, :email, :identifiers]
       serialize_methods :usages
 
       write_access :creator


### PR DESCRIPTION
Limit embedded affiliations attributes to the ones necessary for our UI components, because the calculated attributes may be expansive.
![image](https://github.com/user-attachments/assets/d05963ac-e430-42ee-9f13-47be7da14181)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the set of affiliation attributes displayed for agents to use a fixed list, which may change the affiliation details shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->