### PR TITLE
Fix: Exclude serialized methods from embedded agents

### DIFF
--- a/lib/ontologies_linked_data/models/agents/agent.rb
+++ b/lib/ontologies_linked_data/models/agents/agent.rb
@@ -20,6 +20,8 @@ module LinkedData
       embed_values affiliations: [:name, :agentType, :homepage, :acronym, :email, :identifiers]
       serialize_methods :usages
 
+      prevent_serialize_when_nested :usages  
+          
       write_access :creator
       access_control_load :creator
 


### PR DESCRIPTION
Follow up on this https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/211 , we have a specific implementation for this behaviour, it's used anywhere, that's why i missed it.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serialization behavior to prevent unnecessary data from being included when viewing nested agent details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->