### PR TITLE
Fix: disable copying hasDomain from ontology to submission

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -99,7 +99,7 @@ module LinkedData
       # Usage metadata
       attribute :knownUsage, namespace: :omv, type: :list
       attribute :designedForOntologyTask, namespace: :omv, type: %i[list uri]
-      attribute :hasDomain, namespace: :omv, type: :list, default: ->(s) { ontology_has_domain(s) }
+      attribute :hasDomain, namespace: :omv, type: :list
       attribute :coverage, namespace: :dct
       attribute :example, namespace: :vann, type: :list
 


### PR DESCRIPTION
fix for:
- https://github.com/ontoportal-lirmm/ontologies_linked_data/issues/219
- https://github.com/agroportal/project-management/issues/694